### PR TITLE
Refresh desktop UI with modern theme

### DIFF
--- a/utils/models.py
+++ b/utils/models.py
@@ -25,6 +25,7 @@ from utils.system import (
     start_processing_feedback, stop_processing_feedback,
 )
 from utils.system import get_best_server, CLIENT_ONLY_BUILD
+from utils.ui_theme import apply_modern_theme
 
 
 # ---------------- Env / defaults ----------------
@@ -216,28 +217,40 @@ class DownloadDialog:
 
         self.root = tk.Tk()
         self.root.title("CtrlSpeak Setup")
-        self.root.geometry("420x220")
+        self.root.geometry("480x260")
         self.root.resizable(False, False)
         self.root.attributes("-topmost", True)
+        apply_modern_theme(self.root)
 
-        title = tk.Label(self.root, text="Install Speech Model", font=("Segoe UI", 12, "bold"))
-        title.pack(pady=(12, 4))
+        container = ttk.Frame(self.root, style="Modern.TFrame", padding=(26, 24))
+        container.pack(fill=tk.BOTH, expand=True)
 
-        info_text = ("CtrlSpeak needs to download the Whisper model '"
-                     f"{model_name}' the first time it runs on this PC.")
-        tk.Message(self.root, text=info_text, width=380).pack(pady=(0, 6))
+        card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
+        card.pack(fill=tk.BOTH, expand=True)
+        ttk.Label(card, text="Install speech model", style="Title.TLabel").pack(anchor=tk.W)
 
-        self.stage_var = tk.StringVar(value="Preparing download...")
-        tk.Label(self.root, textvariable=self.stage_var, font=("Segoe UI", 10)).pack(pady=(0, 4))
+        info_text = (
+            "CtrlSpeak needs to download the Whisper model '"
+            f"{model_name}' the first time it runs on this PC."
+        )
+        ttk.Label(card, text=info_text, style="Body.TLabel", wraplength=380,
+                  justify=tk.LEFT).pack(anchor=tk.W, pady=(12, 16))
 
-        self.progress = ttk.Progressbar(self.root, length=360, mode="determinate", maximum=100)
-        self.progress.pack(pady=(0, 4))
+        self.stage_var = tk.StringVar(value="Preparing download…")
+        ttk.Label(card, textvariable=self.stage_var, style="SectionHeading.TLabel").pack(anchor=tk.W)
+
+        self.progress = ttk.Progressbar(card, length=360, mode="determinate", maximum=100,
+                                        style="Modern.Horizontal.TProgressbar")
+        self.progress.pack(fill=tk.X, pady=(12, 8))
 
         self.status_var = tk.StringVar(value="")
-        tk.Label(self.root, textvariable=self.status_var, font=("Segoe UI", 9)).pack(pady=(0, 8))
+        ttk.Label(card, textvariable=self.status_var, style="Caption.TLabel").pack(anchor=tk.W)
 
-        self.cancel_button = ttk.Button(self.root, text="Cancel", command=self.cancel)
-        self.cancel_button.pack()
+        actions = ttk.Frame(card, style="ModernCardInner.TFrame")
+        actions.pack(fill=tk.X, pady=(20, 0))
+        self.cancel_button = ttk.Button(actions, text="Cancel download", style="Danger.TButton",
+                                        command=self.cancel)
+        self.cancel_button.pack(side=tk.RIGHT)
 
         self.root.protocol("WM_DELETE_WINDOW", self.cancel)
 

--- a/utils/ui_theme.py
+++ b/utils/ui_theme.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+# Core palette
+BACKGROUND = "#040913"
+SURFACE = "#0d1a2b"
+ELEVATED_SURFACE = "#122238"
+ACCENT = "#3ad6ff"
+ACCENT_HOVER = "#5ae1ff"
+ACCENT_PRESSED = "#2fbfe3"
+TEXT_PRIMARY = "#e7f2ff"
+TEXT_SECONDARY = "#8fa4c4"
+OUTLINE = "#1b2c44"
+DANGER = "#ff4d6d"
+DANGER_HOVER = "#ff6f88"
+DANGER_PRESSED = "#f03a5a"
+MUTED_BUTTON = "#162a43"
+MUTED_BUTTON_HOVER = "#1f3554"
+MUTED_BUTTON_DISABLED = "#0f1b2c"
+
+
+def apply_modern_theme(root: tk.Misc) -> ttk.Style:
+    """Apply a modern dark style to the provided Tk widget tree."""
+    style = ttk.Style(master=root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        # Fall back silently if the theme isn't available
+        pass
+
+    # Global widget defaults
+    if isinstance(root, tk.Tk) or isinstance(root, tk.Toplevel):
+        root.configure(bg=BACKGROUND)
+    try:
+        root.option_add("*Font", "Segoe UI 10")
+        root.option_add("*Label.Font", "Segoe UI 10")
+        root.option_add("*Background", BACKGROUND)
+        root.option_add("*Foreground", TEXT_PRIMARY)
+        root.option_add("*Entry*Foreground", TEXT_PRIMARY)
+        root.option_add("*Entry*Background", ELEVATED_SURFACE)
+        root.option_add("*Entry*InsertBackground", ACCENT)
+        root.option_add("*TCombobox*Listbox*Background", ELEVATED_SURFACE)
+        root.option_add("*TCombobox*Listbox*Foreground", TEXT_PRIMARY)
+    except Exception:
+        pass
+
+    # Base frames/labels
+    style.configure("Modern.TFrame", background=BACKGROUND)
+    style.configure("ModernCard.TFrame", background=ELEVATED_SURFACE, relief="flat")
+    style.configure("ModernCardInner.TFrame", background=ELEVATED_SURFACE, relief="flat")
+    style.configure("Modern.TLabel", background=BACKGROUND, foreground=TEXT_PRIMARY)
+    style.configure("Body.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY, font=("Segoe UI", 10))
+    style.configure("Title.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    font=("Segoe UI Semibold", 18))
+    style.configure("Subtitle.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_SECONDARY,
+                    font=("Segoe UI", 11))
+    style.configure("SectionHeading.TLabel", background=ELEVATED_SURFACE, foreground=ACCENT,
+                    font=("Segoe UI Semibold", 12))
+    style.configure("Caption.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_SECONDARY,
+                    font=("Segoe UI", 9))
+
+    # Buttons
+    style.configure("Accent.TButton", background=ACCENT, foreground=BACKGROUND,
+                    borderwidth=0, focusthickness=1, focuscolor=ACCENT,
+                    padding=(14, 8))
+    style.map(
+        "Accent.TButton",
+        background=[("disabled", MUTED_BUTTON_DISABLED), ("pressed", ACCENT_PRESSED), ("active", ACCENT_HOVER)],
+        foreground=[("disabled", TEXT_SECONDARY)],
+    )
+
+    style.configure("Subtle.TButton", background=MUTED_BUTTON, foreground=TEXT_PRIMARY,
+                    borderwidth=0, focusthickness=1, focuscolor=OUTLINE,
+                    padding=(14, 8))
+    style.map(
+        "Subtle.TButton",
+        background=[("disabled", MUTED_BUTTON_DISABLED), ("pressed", MUTED_BUTTON), ("active", MUTED_BUTTON_HOVER)],
+        foreground=[("disabled", TEXT_SECONDARY)],
+    )
+
+    style.configure("Danger.TButton", background=DANGER, foreground=BACKGROUND,
+                    borderwidth=0, focusthickness=1, focuscolor=DANGER,
+                    padding=(14, 8))
+    style.map(
+        "Danger.TButton",
+        background=[("disabled", "#5a3240"), ("pressed", DANGER_PRESSED), ("active", DANGER_HOVER)],
+        foreground=[("disabled", "#b37b8a")],
+    )
+
+    # Radio buttons / checkbuttons
+    style.configure("Modern.TRadiobutton", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    focuscolor=ACCENT)
+    style.map(
+        "Modern.TRadiobutton",
+        foreground=[("disabled", TEXT_SECONDARY)],
+        indicatorcolor=[("selected", ACCENT), ("!selected", OUTLINE)],
+    )
+
+    # Combobox
+    style.configure("Modern.TCombobox", fieldbackground=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    background=ELEVATED_SURFACE, bordercolor=OUTLINE, lightcolor=ELEVATED_SURFACE,
+                    darkcolor=ELEVATED_SURFACE, arrowcolor=ACCENT)
+    style.map("Modern.TCombobox",
+              fieldbackground=[("readonly", ELEVATED_SURFACE)],
+              foreground=[("disabled", TEXT_SECONDARY)])
+
+    # Progressbar and separators
+    style.configure("Modern.Horizontal.TProgressbar", troughcolor=MUTED_BUTTON_DISABLED,
+                    background=ACCENT, bordercolor=MUTED_BUTTON_DISABLED,
+                    lightcolor=ACCENT, darkcolor=ACCENT)
+    style.configure("Modern.Horizontal.TSeparator", background=OUTLINE)
+
+    # Accent line helper
+    style.configure("AccentLine.TFrame", background=ACCENT)
+
+    return style


### PR DESCRIPTION
## Summary
- add a reusable futuristic dark theme for Tk-based interfaces
- restyle the splash screen, first-run mode picker, and control center window with modern components
- update the download dialog to match the new visual language

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf883471ec832aabee9272df857d0a