### PR TITLE
Refresh desktop UI with modern theme

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -43,6 +43,7 @@ from utils.ui_theme import (
     apply_modern_theme,
     ELEVATED_SURFACE,
     ACCENT,
+    BACKGROUND,
 )
 
 # Shared UI thread root + instance ref (imported by utils.system.schedule_management_refresh)
@@ -275,7 +276,11 @@ def show_splash_screen(duration_ms: int) -> None:
     pos_x = int((screen_w - width) / 2); pos_y = int((screen_h - height) / 2)
     root.geometry(f"{width}x{height}+{pos_x}+{pos_y}")
 
-    container = tk.Frame(root, bg=ELEVATED_SURFACE, bd=0, highlightthickness=0)
+    shell = tk.Frame(root, bg=BACKGROUND, bd=0, highlightthickness=0)
+    shell.pack(fill=tk.BOTH, expand=True, padx=18, pady=18)
+
+    container = tk.Frame(shell, bg=ELEVATED_SURFACE, bd=0,
+                         highlightbackground=ACCENT, highlightcolor=ACCENT, highlightthickness=1)
     container.pack(fill=tk.BOTH, expand=True)
 
     accent_bar = tk.Frame(container, bg=ACCENT, height=4, bd=0, highlightthickness=0)
@@ -301,6 +306,9 @@ def show_splash_screen(duration_ms: int) -> None:
 
     title_pad = (12, 4) if icon_added else (28, 8)
     ttk.Label(content, text="CtrlSpeak", style="Title.TLabel").pack(pady=title_pad)
+    accent = ttk.Frame(content, style="AccentLine.TFrame")
+    accent.configure(height=2)
+    accent.pack(fill=tk.X, pady=(8, 16))
     ttk.Label(content, text="Initializing voice systems…", style="Subtitle.TLabel",
               wraplength=240, justify=tk.CENTER).pack(pady=(0, 16))
 
@@ -346,7 +354,9 @@ def prompt_initial_mode() -> Optional[str]:
     )
     ttk.Label(intro, text=message, style="Body.TLabel", wraplength=460,
               justify=tk.LEFT).pack(anchor=tk.W, pady=(12, 0))
-    ttk.Separator(intro, style="Modern.Horizontal.TSeparator").pack(fill=tk.X, pady=(18, 4))
+    accent = ttk.Frame(intro, style="AccentLine.TFrame")
+    accent.configure(height=2)
+    accent.pack(fill=tk.X, pady=(18, 8))
 
     cards = ttk.Frame(container, style="Modern.TFrame")
     cards.pack(fill=tk.BOTH, expand=True, pady=(18, 12))
@@ -354,6 +364,11 @@ def prompt_initial_mode() -> Optional[str]:
     def make_card(title: str, desc: str, mode_value: str, primary: bool) -> None:
         card = ttk.Frame(cards, style="ModernCard.TFrame", padding=(22, 20))
         card.pack(fill=tk.X, pady=8)
+        label_text = f"MODE · {mode_value.replace('_', ' ').upper()}"
+        ttk.Label(card, text=label_text, style="PillMuted.TLabel").pack(anchor=tk.W)
+        accent_inner = ttk.Frame(card, style="AccentLine.TFrame")
+        accent_inner.configure(height=2)
+        accent_inner.pack(fill=tk.X, pady=(10, 14))
         ttk.Label(card, text=title, style="SectionHeading.TLabel").pack(anchor=tk.W)
         ttk.Label(card, text=desc, style="Body.TLabel", wraplength=460,
                   justify=tk.LEFT).pack(anchor=tk.W, pady=(10, 16))
@@ -504,12 +519,23 @@ class ManagementWindow:
         ttk.Label(header, text="CtrlSpeak Control", style="Title.TLabel").pack(anchor=tk.W)
         build_label = "Client Only" if CLIENT_ONLY_BUILD else "Client + Server"
         ttk.Label(header, text=f"Build {APP_VERSION} · {build_label}", style="Subtitle.TLabel").pack(anchor=tk.W, pady=(10, 0))
-        ttk.Separator(header, style="Modern.Horizontal.TSeparator").pack(fill=tk.X, pady=(18, 0))
+        header_accent = ttk.Frame(header, style="AccentLine.TFrame")
+        header_accent.configure(height=2)
+        header_accent.pack(fill=tk.X, pady=(18, 0))
 
         # Status overview
         status_card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
         status_card.pack(fill=tk.X, pady=(18, 12))
         ttk.Label(status_card, text="System status", style="SectionHeading.TLabel").pack(anchor=tk.W)
+        status_accent = ttk.Frame(status_card, style="AccentLine.TFrame")
+        status_accent.configure(height=2)
+        status_accent.pack(fill=tk.X, pady=(12, 12))
+        badges = ttk.Frame(status_card, style="ModernCardInner.TFrame")
+        badges.pack(fill=tk.X)
+        self.mode_badge = ttk.Label(badges, text="", style="PillMuted.TLabel")
+        self.mode_badge.pack(side=tk.LEFT)
+        self.network_badge = ttk.Label(badges, text="", style="PillMuted.TLabel")
+        self.network_badge.pack(side=tk.LEFT, padx=(12, 0))
         self.status_var = tk.StringVar()
         self.server_status_var = tk.StringVar()
         ttk.Label(status_card, textvariable=self.status_var, style="Body.TLabel",
@@ -521,6 +547,9 @@ class ManagementWindow:
         device_card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
         device_card.pack(fill=tk.X, pady=(0, 12))
         ttk.Label(device_card, text="Device preference", style="SectionHeading.TLabel").pack(anchor=tk.W)
+        device_accent = ttk.Frame(device_card, style="AccentLine.TFrame")
+        device_accent.configure(height=2)
+        device_accent.pack(fill=tk.X, pady=(10, 12))
         self.device_var = tk.StringVar(value=get_device_preference())
         device_row = ttk.Frame(device_card, style="ModernCardInner.TFrame")
         device_row.pack(fill=tk.X, pady=(14, 10))
@@ -543,6 +572,9 @@ class ManagementWindow:
         model_card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
         model_card.pack(fill=tk.X, pady=(0, 12))
         ttk.Label(model_card, text="Speech model", style="SectionHeading.TLabel").pack(anchor=tk.W)
+        model_accent = ttk.Frame(model_card, style="AccentLine.TFrame")
+        model_accent.configure(height=2)
+        model_accent.pack(fill=tk.X, pady=(10, 12))
         self.model_var = tk.StringVar(value=get_current_model_name())
         model_row = ttk.Frame(model_card, style="ModernCardInner.TFrame")
         model_row.pack(fill=tk.X, pady=(14, 12))
@@ -564,6 +596,9 @@ class ManagementWindow:
         control_card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
         control_card.pack(fill=tk.BOTH, expand=True)
         ttk.Label(control_card, text="Client & server", style="SectionHeading.TLabel").pack(anchor=tk.W)
+        control_accent = ttk.Frame(control_card, style="AccentLine.TFrame")
+        control_accent.configure(height=2)
+        control_accent.pack(fill=tk.X, pady=(10, 12))
         controls = ttk.Frame(control_card, style="ModernCardInner.TFrame")
         controls.pack(fill=tk.X, pady=(14, 0))
         self.start_button = ttk.Button(controls, text="Start client", style="Accent.TButton",
@@ -616,6 +651,21 @@ class ManagementWindow:
         cuda_ok = cuda_runtime_ready()
         model_name = get_current_model_name()
         present = model_files_present(model_store_path_for(model_name))
+        self.mode_badge.configure(text=f"MODE · {mode.upper()}", style="PillAccent.TLabel")
+        network_label = describe_server_status()
+        if "Not connected" in network_label:
+            badge_style = "PillDanger.TLabel"
+            badge_text = "NETWORK · OFFLINE"
+        elif network_label.startswith("Serving"):
+            badge_style = "PillAccent.TLabel"
+            badge_text = "SERVER · ONLINE"
+        elif network_label.startswith("Connected") or network_label.startswith("Discovered"):
+            badge_style = "PillAccent.TLabel"
+            badge_text = "NETWORK · LINKED"
+        else:
+            badge_style = "PillMuted.TLabel"
+            badge_text = "NETWORK · READY"
+        self.network_badge.configure(text=badge_text, style=badge_style)
         status_parts = [
             f"• Mode: {mode}",
             f"• Client: {'active' if sysmod.client_enabled else 'stopped'}",

--- a/utils/models.py
+++ b/utils/models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import os
 import sys
 import time
 import threading
@@ -228,6 +229,11 @@ class DownloadDialog:
         card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
         card.pack(fill=tk.BOTH, expand=True)
         ttk.Label(card, text="Install speech model", style="Title.TLabel").pack(anchor=tk.W)
+        model_tag = ttk.Label(card, text=f"MODEL · {model_name.upper()}", style="PillMuted.TLabel")
+        model_tag.pack(anchor=tk.W, pady=(10, 0))
+        accent = ttk.Frame(card, style="AccentLine.TFrame")
+        accent.configure(height=2)
+        accent.pack(fill=tk.X, pady=(12, 16))
 
         info_text = (
             "CtrlSpeak needs to download the Whisper model '"

--- a/utils/models.py
+++ b/utils/models.py
@@ -25,6 +25,7 @@ from utils.system import (
     start_processing_feedback, stop_processing_feedback,
 )
 from utils.system import get_best_server, CLIENT_ONLY_BUILD
+from utils.ui_theme import apply_modern_theme
 
 
 # ---------------- Env / defaults ----------------
@@ -216,28 +217,40 @@ class DownloadDialog:
 
         self.root = tk.Tk()
         self.root.title("CtrlSpeak Setup")
-        self.root.geometry("420x220")
+        self.root.geometry("480x260")
         self.root.resizable(False, False)
         self.root.attributes("-topmost", True)
+        apply_modern_theme(self.root)
 
-        title = tk.Label(self.root, text="Install Speech Model", font=("Segoe UI", 12, "bold"))
-        title.pack(pady=(12, 4))
+        container = ttk.Frame(self.root, style="Modern.TFrame", padding=(26, 24))
+        container.pack(fill=tk.BOTH, expand=True)
 
-        info_text = ("CtrlSpeak needs to download the Whisper model '"
-                     f"{model_name}' the first time it runs on this PC.")
-        tk.Message(self.root, text=info_text, width=380).pack(pady=(0, 6))
+        card = ttk.Frame(container, style="ModernCard.TFrame", padding=(24, 22))
+        card.pack(fill=tk.BOTH, expand=True)
+        ttk.Label(card, text="Install speech model", style="Title.TLabel").pack(anchor=tk.W)
 
-        self.stage_var = tk.StringVar(value="Preparing download...")
-        tk.Label(self.root, textvariable=self.stage_var, font=("Segoe UI", 10)).pack(pady=(0, 4))
+        info_text = (
+            "CtrlSpeak needs to download the Whisper model '"
+            f"{model_name}' the first time it runs on this PC."
+        )
+        ttk.Label(card, text=info_text, style="Body.TLabel", wraplength=380,
+                  justify=tk.LEFT).pack(anchor=tk.W, pady=(12, 16))
 
-        self.progress = ttk.Progressbar(self.root, length=360, mode="determinate", maximum=100)
-        self.progress.pack(pady=(0, 4))
+        self.stage_var = tk.StringVar(value="Preparing download…")
+        ttk.Label(card, textvariable=self.stage_var, style="SectionHeading.TLabel").pack(anchor=tk.W)
+
+        self.progress = ttk.Progressbar(card, length=360, mode="determinate", maximum=100,
+                                        style="Modern.Horizontal.TProgressbar")
+        self.progress.pack(fill=tk.X, pady=(12, 8))
 
         self.status_var = tk.StringVar(value="")
-        tk.Label(self.root, textvariable=self.status_var, font=("Segoe UI", 9)).pack(pady=(0, 8))
+        ttk.Label(card, textvariable=self.status_var, style="Caption.TLabel").pack(anchor=tk.W)
 
-        self.cancel_button = ttk.Button(self.root, text="Cancel", command=self.cancel)
-        self.cancel_button.pack()
+        actions = ttk.Frame(card, style="ModernCardInner.TFrame")
+        actions.pack(fill=tk.X, pady=(20, 0))
+        self.cancel_button = ttk.Button(actions, text="Cancel download", style="Danger.TButton",
+                                        command=self.cancel)
+        self.cancel_button.pack(side=tk.RIGHT)
 
         self.root.protocol("WM_DELETE_WINDOW", self.cancel)
 

--- a/utils/ui_theme.py
+++ b/utils/ui_theme.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+# NOTE ABOUT FONTS
+# -----------------
+# Windows parses Tk font descriptors token-by-token, so multi-word font
+# families such as "Segoe UI" need to be wrapped in braces when provided as a
+# string literal.  The previous implementation passed values like "Segoe UI 10"
+# into option_add / style.configure, which works on macOS/Linux but raises a
+# TclError on Windows because Tk tries to treat "UI" as the font size.  By
+# explicitly bracing the family portion we keep the value intact and prevent
+# "expected integer but got 'UI'" crashes when creating themed widgets.
+
+# Core palette
+BACKGROUND = "#040913"
+SURFACE = "#0d1a2b"
+ELEVATED_SURFACE = "#122238"
+ACCENT = "#3ad6ff"
+ACCENT_HOVER = "#5ae1ff"
+ACCENT_PRESSED = "#2fbfe3"
+TEXT_PRIMARY = "#e7f2ff"
+TEXT_SECONDARY = "#8fa4c4"
+OUTLINE = "#1b2c44"
+DANGER = "#ff4d6d"
+DANGER_HOVER = "#ff6f88"
+DANGER_PRESSED = "#f03a5a"
+MUTED_BUTTON = "#162a43"
+MUTED_BUTTON_HOVER = "#1f3554"
+MUTED_BUTTON_DISABLED = "#0f1b2c"
+
+
+def apply_modern_theme(root: tk.Misc) -> ttk.Style:
+    """Apply a modern dark style to the provided Tk widget tree."""
+    style = ttk.Style(master=root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        # Fall back silently if the theme isn't available
+        pass
+
+    # Global widget defaults
+    if isinstance(root, tk.Tk) or isinstance(root, tk.Toplevel):
+        root.configure(bg=BACKGROUND)
+    try:
+        root.option_add("*Font", "{Segoe UI} 10")
+        root.option_add("*Label.Font", "{Segoe UI} 10")
+        root.option_add("*Background", BACKGROUND)
+        root.option_add("*Foreground", TEXT_PRIMARY)
+        root.option_add("*Entry*Foreground", TEXT_PRIMARY)
+        root.option_add("*Entry*Background", ELEVATED_SURFACE)
+        root.option_add("*Entry*InsertBackground", ACCENT)
+        root.option_add("*TCombobox*Listbox*Background", ELEVATED_SURFACE)
+        root.option_add("*TCombobox*Listbox*Foreground", TEXT_PRIMARY)
+    except Exception:
+        pass
+
+    # Base frames/labels
+    style.configure("Modern.TFrame", background=BACKGROUND)
+    style.configure("ModernCard.TFrame", background=ELEVATED_SURFACE, relief="flat")
+    style.configure("ModernCardInner.TFrame", background=ELEVATED_SURFACE, relief="flat")
+    style.configure("Modern.TLabel", background=BACKGROUND, foreground=TEXT_PRIMARY)
+    style.configure("Body.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    font=("{Segoe UI}", 10))
+    style.configure("Title.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    font=("{Segoe UI Semibold}", 18))
+    style.configure("Subtitle.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_SECONDARY,
+                    font=("{Segoe UI}", 11))
+    style.configure("SectionHeading.TLabel", background=ELEVATED_SURFACE, foreground=ACCENT,
+                    font=("{Segoe UI Semibold}", 12))
+    style.configure("Caption.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_SECONDARY,
+                    font=("{Segoe UI}", 9))
+
+    # Buttons
+    style.configure("Accent.TButton", background=ACCENT, foreground=BACKGROUND,
+                    borderwidth=0, focusthickness=1, focuscolor=ACCENT,
+                    padding=(14, 8))
+    style.map(
+        "Accent.TButton",
+        background=[("disabled", MUTED_BUTTON_DISABLED), ("pressed", ACCENT_PRESSED), ("active", ACCENT_HOVER)],
+        foreground=[("disabled", TEXT_SECONDARY)],
+    )
+
+    style.configure("Subtle.TButton", background=MUTED_BUTTON, foreground=TEXT_PRIMARY,
+                    borderwidth=0, focusthickness=1, focuscolor=OUTLINE,
+                    padding=(14, 8))
+    style.map(
+        "Subtle.TButton",
+        background=[("disabled", MUTED_BUTTON_DISABLED), ("pressed", MUTED_BUTTON), ("active", MUTED_BUTTON_HOVER)],
+        foreground=[("disabled", TEXT_SECONDARY)],
+    )
+
+    style.configure("Danger.TButton", background=DANGER, foreground=BACKGROUND,
+                    borderwidth=0, focusthickness=1, focuscolor=DANGER,
+                    padding=(14, 8))
+    style.map(
+        "Danger.TButton",
+        background=[("disabled", "#5a3240"), ("pressed", DANGER_PRESSED), ("active", DANGER_HOVER)],
+        foreground=[("disabled", "#b37b8a")],
+    )
+
+    # Radio buttons / checkbuttons
+    style.configure("Modern.TRadiobutton", background=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    focuscolor=ACCENT)
+    style.map(
+        "Modern.TRadiobutton",
+        foreground=[("disabled", TEXT_SECONDARY)],
+        indicatorcolor=[("selected", ACCENT), ("!selected", OUTLINE)],
+    )
+
+    # Combobox
+    style.configure("Modern.TCombobox", fieldbackground=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    background=ELEVATED_SURFACE, bordercolor=OUTLINE, lightcolor=ELEVATED_SURFACE,
+                    darkcolor=ELEVATED_SURFACE, arrowcolor=ACCENT)
+    style.map("Modern.TCombobox",
+              fieldbackground=[("readonly", ELEVATED_SURFACE)],
+              foreground=[("disabled", TEXT_SECONDARY)])
+
+    # Progressbar and separators
+    style.configure("Modern.Horizontal.TProgressbar", troughcolor=MUTED_BUTTON_DISABLED,
+                    background=ACCENT, bordercolor=MUTED_BUTTON_DISABLED,
+                    lightcolor=ACCENT, darkcolor=ACCENT)
+    style.configure("Modern.Horizontal.TSeparator", background=OUTLINE)
+
+    # Accent line helper
+    style.configure("AccentLine.TFrame", background=ACCENT)
+
+    return style

--- a/utils/ui_theme.py
+++ b/utils/ui_theme.py
@@ -26,6 +26,7 @@ OUTLINE = "#1b2c44"
 DANGER = "#ff4d6d"
 DANGER_HOVER = "#ff6f88"
 DANGER_PRESSED = "#f03a5a"
+SUCCESS = "#5cf7c7"
 MUTED_BUTTON = "#162a43"
 MUTED_BUTTON_HOVER = "#1f3554"
 MUTED_BUTTON_DISABLED = "#0f1b2c"
@@ -71,6 +72,12 @@ def apply_modern_theme(root: tk.Misc) -> ttk.Style:
                     font=("{Segoe UI Semibold}", 12))
     style.configure("Caption.TLabel", background=ELEVATED_SURFACE, foreground=TEXT_SECONDARY,
                     font=("{Segoe UI}", 9))
+    style.configure("PillAccent.TLabel", background="#10273b", foreground=ACCENT,
+                    font=("{Segoe UI Semibold}", 9), padding=(12, 4))
+    style.configure("PillDanger.TLabel", background="#34131f", foreground=DANGER,
+                    font=("{Segoe UI Semibold}", 9), padding=(12, 4))
+    style.configure("PillMuted.TLabel", background="#0d1828", foreground=TEXT_SECONDARY,
+                    font=("{Segoe UI}", 9), padding=(12, 4))
 
     # Buttons
     style.configure("Accent.TButton", background=ACCENT, foreground=BACKGROUND,
@@ -116,6 +123,10 @@ def apply_modern_theme(root: tk.Misc) -> ttk.Style:
     style.map("Modern.TCombobox",
               fieldbackground=[("readonly", ELEVATED_SURFACE)],
               foreground=[("disabled", TEXT_SECONDARY)])
+
+    style.configure("Modern.TEntry", fieldbackground=ELEVATED_SURFACE, foreground=TEXT_PRIMARY,
+                    background=ELEVATED_SURFACE, bordercolor=OUTLINE, lightcolor=ELEVATED_SURFACE,
+                    darkcolor=ELEVATED_SURFACE, insertcolor=ACCENT)
 
     # Progressbar and separators
     style.configure("Modern.Horizontal.TProgressbar", troughcolor=MUTED_BUTTON_DISABLED,


### PR DESCRIPTION
## Summary
- wrap Segoe font family names in Tk braces so Windows parses them as a single token
- document the Windows font parsing requirement in the modern theme helper

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf883471ec832aabee9272df857d0a