### PR TITLE
Use cached server status for GUI display

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -483,19 +483,17 @@ def describe_server_status() -> str:
         mode = settings.get("mode")
         port = int(settings.get("server_port", 65432))
 
+    server = sysmod.get_last_connected_server()
+
     if mode == "client_server" and sysmod.server_thread and sysmod.server_thread.is_alive():
-        host = sysmod.last_connected_server.host if sysmod.last_connected_server else sysmod.get_advertised_host_ip()
+        host = server.host if server else sysmod.get_advertised_host_ip()
         return f"Serving: {host}:{port}"
 
-    if sysmod.last_connected_server:
-        host = sysmod.last_connected_server.host
-        prt = sysmod.last_connected_server.port
+    if server:
+        host = server.host
+        prt = server.port
         label = "local CPU" if host == "local-cpu" else ("local" if host == "local" else f"{host}:{prt}")
         return f"Connected: {label}"
-
-    server = sysmod.get_best_server()
-    if server:
-        return f"Discovered: {server.host}:{server.port}"
 
     return "Not connected"
 

--- a/utils/system.py
+++ b/utils/system.py
@@ -486,6 +486,10 @@ def manual_discovery_refresh(wait_time: float = 1.5) -> Optional[ServerInfo]:
     server = _nd_manual_discovery_refresh(discovery_listener, wait_time=wait_time)
     return _apply_last_connected(server)
 
+def get_last_connected_server() -> Optional[ServerInfo]:
+    """Return the most recently discovered or connected server without side effects."""
+    return last_connected_server
+
 def get_best_server() -> Optional[ServerInfo]:
     server = _nd_get_best_server(discovery_listener)
     return _apply_last_connected(server)


### PR DESCRIPTION
## Summary
- add a read-only accessor in utils.system to expose the cached last_connected_server value
- update the GUI status helper to read the cached server info instead of triggering discovery refreshes

## Testing
- python -m utils.sanity_check *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d08d690bd0832a9fcc73c2799b00f4