### PR TITLE
Fix asset paths for PyInstaller build script

### DIFF
--- a/utils/build_exe.py
+++ b/utils/build_exe.py
@@ -16,11 +16,11 @@ except ImportError as exc:  # pragma: no cover - developer convenience
         "PyInstaller is required to build the executable. "
         "Install it with 'pip install pyinstaller'."
     ) from exc
+project_root = Path(__file__).resolve().parent.parent
 
 
 def build() -> None:
-    root = Path(__file__).resolve().parent
-    assets_dir = root / "assets"
+    assets_dir = project_root / "assets"
     icon_path = assets_dir / "icon.ico"
     audio_path = assets_dir / "loading.wav"
 


### PR DESCRIPTION
## Summary
- define the project root relative to the build script and reuse it for PyInstaller inputs
- point the asset directory at the real assets folder so add-data paths resolve correctly

## Testing
- python -m utils.build_exe

------
https://chatgpt.com/codex/tasks/task_e_68d08d705fac832a8833fde025bbd364