### PR TITLE
Guard downloads and auto-activate first model

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -35,6 +35,7 @@ from utils.models import (
     get_current_model_name, set_current_model_name,
     model_store_path_for, model_files_present,
     download_model_with_gui,              # opens progress window and downloads model
+    is_model_loaded,
     format_bytes,                         # optional pretty bytes
 )
 
@@ -53,6 +54,168 @@ management_window: Optional["ManagementWindow"] = None
 
 logger = get_logger(__name__)
 
+# -------- Notification helpers --------
+_busy_popup_win: Optional[tk.Toplevel] = None
+_busy_popup_message: Optional[tk.StringVar] = None
+_busy_popup_progress: Optional[ttk.Progressbar] = None
+_busy_popup_close_job: Optional[str] = None
+
+
+def show_notification_popup(title: str, message: str) -> None:
+    """Display a simple informational dialog."""
+    if tk_root is None or not tk_root.winfo_exists():
+        return
+    try:
+        messagebox.showinfo(title, message, parent=tk_root)
+    except Exception:
+        logger.exception("Failed to display notification popup: %s", title)
+
+
+def _cancel_busy_popup_close() -> None:
+    global _busy_popup_close_job
+    if _busy_popup_win is not None and _busy_popup_close_job is not None:
+        try:
+            _busy_popup_win.after_cancel(_busy_popup_close_job)
+        except Exception:
+            logger.exception("Failed to cancel activation popup close timer")
+    _busy_popup_close_job = None
+
+
+def _destroy_busy_popup() -> None:
+    global _busy_popup_win, _busy_popup_message, _busy_popup_progress, _busy_popup_close_job
+    if _busy_popup_win is not None and _busy_popup_win.winfo_exists():
+        try:
+            _busy_popup_win.destroy()
+        except Exception:
+            logger.exception("Failed to destroy activation popup window")
+    _busy_popup_win = None
+    _busy_popup_message = None
+    _busy_popup_progress = None
+    _busy_popup_close_job = None
+
+
+def show_activation_popup(message: str) -> None:
+    """Create or update the activation progress popup."""
+    global _busy_popup_win, _busy_popup_message, _busy_popup_progress
+    if tk_root is None or not tk_root.winfo_exists():
+        return
+
+    _cancel_busy_popup_close()
+
+    if _busy_popup_win is None or not _busy_popup_win.winfo_exists():
+        _busy_popup_win = tk.Toplevel(tk_root)
+        _busy_popup_win.title("CtrlSpeak is preparing")
+        _busy_popup_win.geometry("420x220")
+        _busy_popup_win.resizable(False, False)
+        _busy_popup_win.attributes("-topmost", True)
+        try:
+            _busy_popup_win.attributes("-toolwindow", True)
+        except Exception:
+            # Not all platforms support this hint
+            pass
+        apply_modern_theme(_busy_popup_win)
+        _busy_popup_win.protocol("WM_DELETE_WINDOW", lambda: None)
+
+        container = ttk.Frame(_busy_popup_win, style="Modern.TFrame", padding=(24, 22))
+        container.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(container, text="Preparing CtrlSpeak", style="Title.TLabel").pack(anchor=tk.W)
+
+        _busy_popup_message = tk.StringVar(value=message)
+        ttk.Label(
+            container,
+            textvariable=_busy_popup_message,
+            style="Body.TLabel",
+            wraplength=360,
+            justify=tk.LEFT,
+        ).pack(anchor=tk.W, pady=(12, 20))
+
+        _busy_popup_progress = ttk.Progressbar(
+            container,
+            mode="indeterminate",
+            length=340,
+            style="Modern.Horizontal.TProgressbar",
+        )
+        _busy_popup_progress.pack(fill=tk.X)
+        try:
+            _busy_popup_progress.start(12)
+        except Exception:
+            logger.exception("Failed to start activation popup progress bar")
+    else:
+        try:
+            _busy_popup_win.deiconify()
+            _busy_popup_win.lift()
+        except Exception:
+            logger.exception("Failed to raise activation popup window")
+
+    if _busy_popup_message is not None:
+        _busy_popup_message.set(message)
+    if _busy_popup_progress is not None:
+        try:
+            _busy_popup_progress.config(mode="indeterminate")
+            _busy_popup_progress.start(12)
+        except Exception:
+            logger.exception("Failed to restart activation popup progress bar")
+
+    try:
+        _busy_popup_win.lift()
+        _busy_popup_win.focus_force()
+    except Exception:
+        # Focus hints may fail in some environments
+        pass
+
+
+def focus_activation_popup(message: Optional[str] = None) -> None:
+    """Bring the activation popup to the foreground."""
+    if message:
+        show_activation_popup(message)
+        return
+
+    if _busy_popup_win is None or not _busy_popup_win.winfo_exists():
+        return
+
+    _cancel_busy_popup_close()
+    try:
+        _busy_popup_win.deiconify()
+        _busy_popup_win.lift()
+        _busy_popup_win.focus_force()
+    except Exception:
+        pass
+
+
+def close_activation_popup(message: Optional[str] = None) -> None:
+    """Stop the busy popup and close it, optionally after showing a final message."""
+    global _busy_popup_close_job
+    if _busy_popup_win is None or not _busy_popup_win.winfo_exists():
+        if message:
+            show_notification_popup("CtrlSpeak", message)
+        return
+
+    _cancel_busy_popup_close()
+
+    if _busy_popup_progress is not None:
+        try:
+            _busy_popup_progress.stop()
+            _busy_popup_progress.config(mode="determinate", maximum=100, value=100)
+        except Exception:
+            logger.exception("Failed to update activation popup progress state")
+
+    if message and _busy_popup_message is not None:
+        _busy_popup_message.set(message)
+
+    if message:
+        try:
+            _busy_popup_win.lift()
+        except Exception:
+            pass
+        # Leave the completion message visible briefly before closing
+        try:
+            _busy_popup_close_job = _busy_popup_win.after(2400, _destroy_busy_popup)
+        except Exception:
+            logger.exception("Failed to schedule activation popup dismissal")
+            _destroy_busy_popup()
+    else:
+        _destroy_busy_popup()
 # -------- Voice Waveform Overlay --------
 _waveform_win: Optional[tk.Toplevel] = None
 _waveform_canvas: Optional[tk.Canvas] = None
@@ -861,9 +1024,18 @@ class ManagementWindow:
         name = self.model_var.get()
         if name not in {"small", "large-v3"}:
             name = "large-v3"
-        if download_model_with_gui(name):
+        model_already_loaded = is_model_loaded()
+        if download_model_with_gui(
+            name,
+            block_during_download=not model_already_loaded,
+            activate_after=not model_already_loaded,
+        ):
             (model_store_path_for(name) / ".installed").touch(exist_ok=True)
-            messagebox.showinfo("Model", "Model downloaded successfully.", parent=self.window)
+            if model_already_loaded:
+                message = "Model downloaded successfully."
+            else:
+                message = "Model downloaded and activated successfully."
+            messagebox.showinfo("Model", message, parent=self.window)
         else:
             messagebox.showwarning("Model", "Model download did not complete.", parent=self.window)
         self.refresh_status()

--- a/utils/models.py
+++ b/utils/models.py
@@ -6,9 +6,10 @@ import sys
 import time
 import threading
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from queue import Queue, Empty
-from typing import Optional, List, Set
+from typing import Optional, List, Set, Callable
 
 import ctypes
 import ctranslate2
@@ -28,6 +29,7 @@ from utils.system import (
     notify, notify_error, format_exception_details,
     get_config_dir, save_settings,
     start_processing_feedback, stop_processing_feedback,
+    ui_show_activation_popup, ui_close_activation_popup,
 )
 from utils.system import get_best_server, CLIENT_ONLY_BUILD
 from utils.ui_theme import apply_modern_theme
@@ -196,13 +198,32 @@ def install_cuda_runtime_with_progress(parent=None) -> bool:
         "--extra-index-url", "https://pypi.nvidia.com",
         *pkgs
     ]
-    rc = _run_cmd_stream(cmd, timeout=600)
-    if rc != 0:
-        notify("CUDA runtime installation failed (pip returned non-zero).")
-        return False
-    # refresh DLL search path + verify
-    time.sleep(0.5)
-    return cuda_runtime_ready(ignore_preference=True)
+    with activation_guard(
+        "installing CUDA runtime components",
+        busy_message=(
+            "CtrlSpeak is installing CUDA runtime components required for GPU transcription. "
+            "Please wait for this to finish."
+        ),
+        success_message=(
+            "CUDA runtime components are ready. CtrlSpeak will continue preparing the Whisper model."
+        ),
+        failure_message=(
+            "CUDA runtime installation did not complete. CtrlSpeak will continue without GPU acceleration."
+        ),
+    ) as complete:
+        rc = _run_cmd_stream(cmd, timeout=600)
+        if rc != 0:
+            notify("CUDA runtime installation failed (pip returned non-zero).")
+            complete(False, "CUDA runtime installation failed. CtrlSpeak will continue using the CPU.")
+            return False
+        # refresh DLL search path + verify
+        time.sleep(0.5)
+        ready = cuda_runtime_ready(ignore_preference=True)
+        if not ready:
+            complete(False, "CtrlSpeak installed the CUDA runtime but could not validate the GPU libraries.")
+            return False
+        complete(True, "CUDA runtime components were installed successfully. Continuing activation…")
+        return True
 
 
 # ---------------- Download dialog (GUI) ----------------
@@ -375,7 +396,12 @@ def _prompt_for_model_install(model_name: str) -> bool:
     return choice == "Install Now"
 
 
-def download_model_with_gui(model_short: Optional[str] = None) -> bool:
+def download_model_with_gui(
+    model_short: Optional[str] = None,
+    *,
+    block_during_download: bool = False,
+    activate_after: bool = False,
+) -> bool:
     """
     Download the selected model (or the argument provided) with a simple progress dialog.
     Keeps files under %APPDATA%/CtrlSpeak/models/<model>.
@@ -414,9 +440,40 @@ def download_model_with_gui(model_short: Optional[str] = None) -> bool:
 
     thread = threading.Thread(target=worker, daemon=True)
     thread.start()
-    result = dialog.run()
-    thread.join(timeout=0.5)
-    return result == "success"
+    def _run() -> bool:
+        result = dialog.run()
+        thread.join(timeout=0.5)
+        return result == "success"
+
+    if not block_during_download:
+        return _run()
+
+    with activation_guard(
+        "downloading the Whisper model",
+        busy_message="CtrlSpeak is downloading the Whisper model. Please wait for the download to finish before using CtrlSpeak.",
+        success_message="The Whisper model download completed successfully.",
+        failure_message="CtrlSpeak could not download the Whisper model. Please try again.",
+    ) as finalize:
+        success = _run()
+        if not success:
+            finalize(False, "CtrlSpeak could not download the Whisper model. Please try again.")
+            return False
+
+        if not activate_after:
+            finalize(True, "The Whisper model download completed successfully.")
+            return True
+
+        try:
+            ui_show_activation_popup("The Whisper model has been downloaded. Activating it now…")
+        except Exception:
+            logger.exception("Failed to update activation popup before model activation")
+
+        activated = initialize_transcriber(
+            force=True,
+            allow_client=True,
+            activation_finalizer=finalize,
+        )
+        return activated is not None
 
 
 # ---------------- Transcriber ----------------
@@ -425,6 +482,122 @@ whisper_model: Optional[WhisperModel] = None
 model_ready = threading.Event()
 warned_cuda_unavailable = False
 _missing_model_notified: Set[str] = set()
+
+# Track long-running activation/installation work so the hotkey can be gated.
+_activation_event = threading.Event()
+_activation_lock = threading.Lock()
+_activation_reasons: list[str] = []
+
+
+def is_model_loaded() -> bool:
+    with model_lock:
+        return whisper_model is not None
+
+
+def _activation_busy_message(reason: str) -> str:
+    clean = reason.rstrip(". ")
+    return (
+        "CtrlSpeak is busy "
+        f"{clean}. Please wait for this to finish before using CtrlSpeak."
+    )
+
+
+def _activation_success_message(reason: str) -> str:
+    clean = reason.rstrip(". ")
+    return f"Finished {clean}. CtrlSpeak is ready to use."
+
+
+def _activation_failure_message(reason: str) -> str:
+    clean = reason.rstrip(". ")
+    return (
+        f"CtrlSpeak could not finish {clean}. "
+        "Please review the logs or try again."
+    )
+
+
+def _begin_activation(reason: str, busy_message: str) -> None:
+    with _activation_lock:
+        _activation_reasons.append(reason)
+        _activation_event.set()
+    try:
+        ui_show_activation_popup(busy_message)
+    except Exception:
+        logger.exception("Failed to present activation busy popup")
+
+
+def _end_activation(reason: str, *, success: bool, message: Optional[str]) -> None:
+    new_top: Optional[str] = None
+    with _activation_lock:
+        if _activation_reasons:
+            _activation_reasons.pop()
+        if _activation_reasons:
+            new_top = _activation_reasons[-1]
+        else:
+            _activation_event.clear()
+    if new_top:
+        try:
+            ui_show_activation_popup(_activation_busy_message(new_top))
+        except Exception:
+            logger.exception("Failed to refresh activation popup message")
+        return
+
+    final_text = message
+    if final_text is None:
+        final_text = (
+            _activation_success_message(reason)
+            if success else _activation_failure_message(reason)
+        )
+    try:
+        ui_close_activation_popup(final_text)
+    except Exception:
+        logger.exception("Failed to close activation popup")
+
+
+@contextmanager
+def activation_guard(
+    reason: str,
+    *,
+    busy_message: Optional[str] = None,
+    success_message: Optional[str] = None,
+    failure_message: Optional[str] = None,
+):
+    """Track long-running activation work and drive the busy popup lifecycle."""
+    busy = busy_message or _activation_busy_message(reason)
+    _begin_activation(reason, busy)
+    outcome = {"success": True, "message": success_message}
+
+    def finalize(success: bool, message: Optional[str] = None) -> None:
+        outcome["success"] = bool(success)
+        outcome["message"] = message
+
+    try:
+        yield finalize
+    except Exception:
+        _end_activation(reason, success=False, message=failure_message)
+        raise
+    else:
+        final_message = outcome["message"]
+        if outcome["success"]:
+            if final_message is None:
+                final_message = _activation_success_message(reason)
+        else:
+            if final_message is None:
+                final_message = failure_message or _activation_failure_message(reason)
+        _end_activation(reason, success=outcome["success"], message=final_message)
+
+
+def is_activation_in_progress() -> bool:
+    return _activation_event.is_set()
+
+
+def describe_activation_block() -> Optional[str]:
+    if not _activation_event.is_set():
+        return None
+    with _activation_lock:
+        reason = _activation_reasons[-1] if _activation_reasons else None
+    if reason:
+        return _activation_busy_message(reason)
+    return "CtrlSpeak is preparing resources. Please wait before using the app."
 
 def _force_cpu_env() -> None:
     """
@@ -485,7 +658,11 @@ def _ensure_model_available_active(interactive: bool = True) -> bool:
         if not _prompt_for_model_install(name):
             notify("CtrlSpeak cannot transcribe without the Whisper model. You can install it next time you start the app.")
             return False
-        if not download_model_with_gui(name):
+        block_download = whisper_model is None
+        if not download_model_with_gui(
+            name,
+            block_during_download=block_download,
+        ):
             notify("The Whisper model was not installed. Try again later or check your internet connection.")
             return False
     if model_files_present(store):
@@ -522,19 +699,75 @@ def initialize_transcriber(
     allow_client: bool = False,
     preferred_device: Optional[str] = None,
     interactive: bool = True,
+    activation_finalizer: Optional[Callable[[bool, Optional[str]], None]] = None,
 ) -> Optional[WhisperModel]:
     """
     Loads the Whisper model selected in settings into faster-whisper with the active device choice.
     """
     global whisper_model, warned_cuda_unavailable
+
+    def perform_activation(finalize: Callable[[bool, Optional[str]], None]) -> Optional[WhisperModel]:
+        nonlocal device, compute_type, model_name
+        global whisper_model, warned_cuda_unavailable
+
+        if device == "cpu":
+            _force_cpu_env()
+
+        try:
+            whisper_model = WhisperModel(
+                model_name,
+                device=device,
+                compute_type=compute_type,
+                download_root=str(MODEL_ROOT_PATH),
+            )
+            print(f"Whisper model '{model_name}' ready on {device} ({compute_type})")
+            finalize(True, f"The Whisper model '{model_name}' is ready on {device.upper()} ({compute_type}).")
+            return whisper_model
+        except Exception as exc:
+            print(f"Failed to load model on {device}: {exc}")
+            logger.exception("Failed to load Whisper model on %s", device)
+            if device != "cpu":
+                try:
+                    whisper_model = WhisperModel(
+                        model_name,
+                        device="cpu",
+                        compute_type="int8",
+                        download_root=str(MODEL_ROOT_PATH),
+                    )
+                    notify("Running CtrlSpeak transcription on CPU fallback. Set CTRLSPEAK_DEVICE=cpu to suppress this message.")
+                    warned_cuda_unavailable = True
+                    finalize(
+                        True,
+                        f"The Whisper model '{model_name}' is ready on CPU fallback. CtrlSpeak will continue using the CPU.",
+                    )
+                    return whisper_model
+                except Exception as cpu_exc:
+                    print(f"CPU fallback failed: {cpu_exc}")
+                    logger.exception("CPU fallback model load failed")
+            notify("Unable to initialize the transcription model. Please check your installation and try again.")
+            finalize(
+                False,
+                "CtrlSpeak was unable to activate the Whisper model. Please check your installation and try again.",
+            )
+            whisper_model = None
+            return None
+
     with model_lock:
         if whisper_model is not None and not force:
+            if activation_finalizer is not None:
+                activation_finalizer(True, None)
             return whisper_model
+
         with settings_lock:
             mode = settings.get("mode")
         if not allow_client and mode != "client_server":
+            if activation_finalizer is not None:
+                activation_finalizer(False, "CtrlSpeak is not running in local transcription mode.")
             return None
+
         if not _ensure_model_available_active(interactive=interactive):
+            if activation_finalizer is not None:
+                activation_finalizer(False, "CtrlSpeak could not find the Whisper model files.")
             return None
 
         device = preferred_device or resolve_device()
@@ -553,40 +786,16 @@ def initialize_transcriber(
         compute_type = resolve_compute_type(device)
         model_name = get_current_model_name()
 
-        # >>> add this guard <<<
-        if device == "cpu":
-            _force_cpu_env()
+        if activation_finalizer is None:
+            with activation_guard(
+                "activating the Whisper model",
+                busy_message="CtrlSpeak is activating the Whisper model. Please wait for the model to finish preparing.",
+                success_message="The Whisper model is ready. You may now use CtrlSpeak.",
+                failure_message="CtrlSpeak could not activate the Whisper model.",
+            ) as complete:
+                return perform_activation(complete)
 
-        try:
-            whisper_model = WhisperModel(
-                model_name,
-                device=device,
-                compute_type=compute_type,
-                download_root=str(MODEL_ROOT_PATH),
-            )
-            print(f"Whisper model '{model_name}' ready on {device} ({compute_type})")
-            return whisper_model
-        except Exception as exc:
-            print(f"Failed to load model on {device}: {exc}")
-            logger.exception("Failed to load Whisper model on %s", device)
-            if device != "cpu":
-                try:
-                    whisper_model = WhisperModel(
-                        model_name,
-                        device="cpu",
-                        compute_type="int8",
-                        download_root=str(MODEL_ROOT_PATH),
-                    )
-                    notify("Running CtrlSpeak transcription on CPU fallback. Set CTRLSPEAK_DEVICE=cpu to suppress this message.")
-                    warned_cuda_unavailable = True
-                    return whisper_model
-                except Exception as cpu_exc:
-                    print(f"CPU fallback failed: {cpu_exc}")
-                    logger.exception("CPU fallback model load failed")
-            notify("Unable to initialize the transcription model. Please check your installation and try again.")
-            whisper_model = None
-            return None
-
+        return perform_activation(activation_finalizer)
 
 # ---------------- Transcription API ----------------
 def collect_text_from_segments(segments) -> str:

--- a/utils/system.py
+++ b/utils/system.py
@@ -174,10 +174,65 @@ last_connected_server: Optional[ServerInfo] = None
 
 # ---------------- Notifications / logging ----------------
 def notify(message: str, title: str = "CtrlSpeak") -> None:
+    """Display a user-facing notification window (falls back to stdout)."""
     try:
-        print(f"{title}: {message}")
+        from utils.gui import ensure_management_ui_thread, show_notification_popup
+
+        ensure_management_ui_thread()
+        enqueue_management_task(show_notification_popup, title, message)
     except Exception:
         logger.exception("Failed to display notification '%s': %s", title, message)
+        try:
+            print(f"{title}: {message}")
+        except Exception:
+            logger.exception("Failed to print fallback notification '%s'", title)
+
+
+def ui_show_activation_popup(message: str) -> None:
+    """Show (or update) the activation-in-progress popup."""
+    try:
+        from utils.gui import ensure_management_ui_thread, show_activation_popup
+
+        ensure_management_ui_thread()
+        enqueue_management_task(show_activation_popup, message)
+    except Exception:
+        logger.exception("Failed to show activation popup")
+        try:
+            print(f"CtrlSpeak: {message}")
+        except Exception:
+            logger.exception("Failed to print activation popup fallback message")
+
+
+def ui_remind_activation_popup(message: str | None = None) -> None:
+    """Bring the activation popup to the foreground (optionally updating its text)."""
+    try:
+        from utils.gui import ensure_management_ui_thread, focus_activation_popup
+
+        ensure_management_ui_thread()
+        enqueue_management_task(focus_activation_popup, message)
+    except Exception:
+        logger.exception("Failed to focus activation popup")
+        if message:
+            try:
+                print(f"CtrlSpeak: {message}")
+            except Exception:
+                logger.exception("Failed to print activation popup focus message")
+
+
+def ui_close_activation_popup(message: str | None = None) -> None:
+    """Close the activation popup, optionally leaving a completion message first."""
+    try:
+        from utils.gui import ensure_management_ui_thread, close_activation_popup
+
+        ensure_management_ui_thread()
+        enqueue_management_task(close_activation_popup, message)
+    except Exception:
+        logger.exception("Failed to close activation popup")
+        if message:
+            try:
+                print(f"CtrlSpeak: {message}")
+            except Exception:
+                logger.exception("Failed to print activation popup completion message")
 
 def format_exception_details(exc: Exception) -> str:
     return "".join(traceback.format_exception_only(type(exc), exc)).strip()
@@ -417,9 +472,15 @@ def record_audio(target_path: Path) -> None:
 
 # ---------------- Client keyboard listener ----------------
 def on_press(key):
-    from utils.models import transcribe_audio  # imported on-demand to avoid circulars
+    from utils.models import describe_activation_block, is_activation_in_progress  # on-demand to avoid circulars
     global recording, recording_thread, recording_file_path
     if not client_enabled: return
+    if is_activation_in_progress():
+        message = describe_activation_block()
+        if not message:
+            message = "CtrlSpeak is busy preparing resources. Please wait before using the hotkey again."
+        ui_remind_activation_popup(message)
+        return
     if key == keyboard.Key.ctrl_r and not recording:
         recording = True
         recording_file_path = create_recording_file_path()
@@ -433,13 +494,30 @@ def on_press(key):
 
 
 def on_release(key):
-    from utils.models import transcribe_audio
+    from utils.models import describe_activation_block, is_activation_in_progress, transcribe_audio
     global recording, recording_thread, recording_file_path
     if key == keyboard.Key.ctrl_r:
         if recording:
             recording = False
             if recording_thread:
                 recording_thread.join(); recording_thread = None
+            path = recording_file_path
+            block_message = None
+            try:
+                if is_activation_in_progress():
+                    block_message = describe_activation_block()
+            except Exception:
+                logger.exception("Failed to check activation status before transcription")
+            if block_message:
+                ui_remind_activation_popup(block_message)
+                try:
+                    from utils.gui import hide_waveform_overlay
+                    enqueue_management_task(hide_waveform_overlay)
+                except Exception:
+                    logger.exception("Failed to hide waveform overlay after activation block")
+                cleanup_recording_file(path)
+                recording_file_path = None
+                return
             # switch overlay into “processing” mode
             try:
                 from utils.gui import set_waveform_processing
@@ -451,7 +529,6 @@ def on_release(key):
                 start_processing_feedback()
             except Exception:
                 logger.exception("Failed to start processing feedback loop")
-            path = recording_file_path
             text = None
             try:
                 if path and path.exists() and path.stat().st_size > 0:


### PR DESCRIPTION
## Summary
- gate first-time Whisper downloads with the activation popup and reuse the same guard to launch activation automatically when no model is active
- expose an `is_model_loaded` helper and update the management UI to auto-activate the first downloaded model while still allowing background downloads when another model stays active
- allow `initialize_transcriber` to reuse an existing activation guard so sequential download+activation updates the same notification flow

## Testing
- python -m py_compile utils/models.py utils/system.py utils/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68d08c08a578832a9ecb430fef098633