### PR TITLE
Ensure activation popup transitions after model download

### DIFF
--- a/utils/models.py
+++ b/utils/models.py
@@ -464,7 +464,9 @@ def download_model_with_gui(
             return True
 
         try:
-            ui_show_activation_popup("The Whisper model has been downloaded. Activating it now…")
+            ui_show_activation_popup(
+                "CtrlSpeak is activating the Whisper model. Please wait while the model starts up…"
+            )
         except Exception:
             logger.exception("Failed to update activation popup before model activation")
 
@@ -721,7 +723,13 @@ def initialize_transcriber(
                 download_root=str(MODEL_ROOT_PATH),
             )
             print(f"Whisper model '{model_name}' ready on {device} ({compute_type})")
-            finalize(True, f"The Whisper model '{model_name}' is ready on {device.upper()} ({compute_type}).")
+            finalize(
+                True,
+                (
+                    "Activation complete! You can now use CtrlSpeak. "
+                    f"The Whisper model '{model_name}' is ready on {device.upper()} ({compute_type})."
+                ),
+            )
             return whisper_model
         except Exception as exc:
             print(f"Failed to load model on {device}: {exc}")
@@ -738,7 +746,10 @@ def initialize_transcriber(
                     warned_cuda_unavailable = True
                     finalize(
                         True,
-                        f"The Whisper model '{model_name}' is ready on CPU fallback. CtrlSpeak will continue using the CPU.",
+                        (
+                            "Activation complete! You can now use CtrlSpeak. "
+                            f"The Whisper model '{model_name}' is running on the CPU fallback."
+                        ),
                     )
                     return whisper_model
                 except Exception as cpu_exc:

--- a/utils/system.py
+++ b/utils/system.py
@@ -191,10 +191,17 @@ def notify(message: str, title: str = "CtrlSpeak") -> None:
 def ui_show_activation_popup(message: str) -> None:
     """Show (or update) the activation-in-progress popup."""
     try:
-        from utils.gui import ensure_management_ui_thread, show_activation_popup
+        from utils.gui import (
+            ensure_management_ui_thread,
+            show_activation_popup,
+            is_management_ui_thread,
+        )
 
         ensure_management_ui_thread()
-        enqueue_management_task(show_activation_popup, message)
+        if is_management_ui_thread():
+            show_activation_popup(message)
+        else:
+            enqueue_management_task(show_activation_popup, message)
     except Exception:
         logger.exception("Failed to show activation popup")
         try:
@@ -222,10 +229,17 @@ def ui_remind_activation_popup(message: str | None = None) -> None:
 def ui_close_activation_popup(message: str | None = None) -> None:
     """Close the activation popup, optionally leaving a completion message first."""
     try:
-        from utils.gui import ensure_management_ui_thread, close_activation_popup
+        from utils.gui import (
+            ensure_management_ui_thread,
+            close_activation_popup,
+            is_management_ui_thread,
+        )
 
         ensure_management_ui_thread()
-        enqueue_management_task(close_activation_popup, message)
+        if is_management_ui_thread():
+            close_activation_popup(message)
+        else:
+            enqueue_management_task(close_activation_popup, message)
     except Exception:
         logger.exception("Failed to close activation popup")
         if message:


### PR DESCRIPTION
## Summary
- track the management UI thread identity so activation popups can update immediately when running on the GUI thread
- update activation popup helpers to run synchronously when already on the management UI thread and refresh messaging during activation
- refresh activation messaging to cover the transition from download to activation and confirm completion once the Whisper model is ready

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_68d09eaacb04832a8bbcc7d1170f2da0