### PR TITLE
Support auto-setup profile selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from utils.system import (
     CLIENT_ONLY_BUILD,
     start_server,
     run_tray,
+    apply_auto_setup,
 )
 
 from utils.gui import show_splash_screen, ensure_mode_selected
@@ -43,6 +44,9 @@ def main(argv: list[str]) -> int:
 
     # Load settings early
     load_settings()
+
+    if args.auto_setup:
+        apply_auto_setup(args.auto_setup)
 
     # CLI: offline transcription of a file
     if args.transcribe:

--- a/utils/system.py
+++ b/utils/system.py
@@ -888,5 +888,6 @@ def transcribe_cli(target: str) -> int:
 def apply_auto_setup(profile: str) -> None:
     global AUTO_MODE, AUTO_MODE_PROFILE
     AUTO_MODE = True; AUTO_MODE_PROFILE = profile
+    logger.info("Applying auto-setup profile: %s", profile)
     with settings_lock: settings["mode"] = profile
     save_settings()


### PR DESCRIPTION
## Summary
- import and invoke the auto-setup helper during startup so CLI profiles persist before prompting
- log auto-setup usage when persisting the selected mode

## Testing
- python -m compileall main.py utils

------
https://chatgpt.com/codex/tasks/task_e_68d0a697a8b8832aa8bccba9667b657b