### PR TITLE
Auto-download Whisper model when enabling local server mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from utils.system import (
 )
 
 from utils.gui import show_splash_screen, ensure_mode_selected
-from utils.models import initialize_transcriber
+from utils.models import initialize_transcriber, ensure_model_ready_for_local_server
 
 
 def main(argv: list[str]) -> int:
@@ -58,12 +58,17 @@ def main(argv: list[str]) -> int:
     # Ensure mode selected (client or client_server)
     ensure_mode_selected()
 
-    # Start discovery listener for client mode visibility
-    start_discovery_listener()
-
-    # Orchestrate engine/server as needed based on mode
+    # Determine the selected mode now that setup is complete
     with settings_lock:
         mode = settings.get("mode")
+
+    # Automatically prepare local transcription assets when running the server locally
+    if mode == "client_server":
+        if not ensure_model_ready_for_local_server():
+            return 0
+
+    # Start discovery listener for client mode visibility
+    start_discovery_listener()
 
     if mode == "client_server":
         initialize_transcriber(interactive=False)   # warm-up local model when assets are ready

--- a/utils/models.py
+++ b/utils/models.py
@@ -508,6 +508,27 @@ model_ready = threading.Event()
 warned_cuda_unavailable = False
 _missing_model_notified: Set[str] = set()
 
+
+def ensure_model_ready_for_local_server() -> bool:
+    """Ensure a Whisper model is available and activated for local server mode."""
+
+    with model_lock:
+        if whisper_model is not None:
+            return True
+
+    model_name = get_current_model_name()
+    store = model_store_path_for(model_name)
+    marker = store / ".installed"
+
+    if model_files_present(store) and marker.exists():
+        return True
+
+    return download_model_with_gui(
+        model_name,
+        block_during_download=True,
+        activate_after=True,
+    )
+
 # Track long-running activation/installation work so the hotkey can be gated.
 _activation_event = threading.Event()
 _activation_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- automatically download and activate the Whisper model when entering client + server mode without an installed model
- block startup of the local server until the model is ready instead of showing the tray instructions

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0af5ff144832aace08b6ed83abe12