### PR TITLE
Fix activation popup thread error and allow resizing download dialog

### DIFF
--- a/utils/models.py
+++ b/utils/models.py
@@ -251,7 +251,8 @@ class DownloadDialog:
         self.root = tk.Tk()
         self.root.title("CtrlSpeak Setup")
         self.root.geometry("480x260")
-        self.root.resizable(False, False)
+        self.root.minsize(440, 240)
+        self.root.resizable(True, True)
         self.root.attributes("-topmost", True)
         apply_modern_theme(self.root)
 


### PR DESCRIPTION
## Summary
- replace the activation popup's StringVar usage with a label helper so that status updates no longer raise thread errors
- keep the activation popup text updated safely while preserving its indeterminate progress bar
- allow the speech-model download dialog to be resized while retaining a sensible minimum size

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_68d0b39a3f30832a800b9587d2a09fed