### PR TITLE
docs: refresh README layout and cli flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Both flavours support Windows 10/11, enforce a single running instance, expose a
 ## Repository Layout
 
 - `main.py` – application entry point.
-- `build_exe.py` – helper script that runs PyInstaller with the correct data files.
 - `assets/` – static resources such as the tray icon (`icon.ico`) and processing chime (`loading.wav`).
 - `utils/` – implementation modules (GUI, models, networking, configuration helpers, etc.).
-- `serverportsetup.txt` – Windows PowerShell commands to open discovery/API firewall ports.
+- `utils/build_exe.py` – helper script that runs PyInstaller with the correct data files.
+- `packaging/` – PyInstaller spec (`CtrlSpeak.spec`) and additional build documentation.
 
 Generated folders such as `dist/` and `build/` are ignored via `.gitignore`.
 
@@ -36,6 +36,7 @@ On first launch you will be prompted to choose between **Client + Server** or **
 
 ### Command-line Flags
 
+- `--auto-setup {client,client_server}` – pre-select the startup mode without showing the GUI prompts.
 - `--force-sendinput` – force the AnyDesk-compatible synthetic keystroke path.
 - `--transcribe <wav>` – batch process an audio file without the hotkey workflow.
 - `--uninstall` – remove the application data and executable (used by the packaged build).


### PR DESCRIPTION
## Summary
- update the repository layout section to reference utils/build_exe.py and the packaging folder while removing stale files
- document the --auto-setup CLI flag alongside the other command-line options

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d0c1e1765c832aa69e5f449a81f1c1