### PR TITLE
Improve model download and activation progress UI

### DIFF
--- a/utils/system.py
+++ b/utils/system.py
@@ -248,6 +248,21 @@ def ui_close_activation_popup(message: str | None = None) -> None:
             except Exception:
                 logger.exception("Failed to print activation popup completion message")
 
+
+def ui_update_activation_progress(
+    progress: float | None,
+    elapsed: float | None,
+    eta: float | None,
+) -> None:
+    """Update the activation popup progress bar and timing information."""
+    try:
+        from utils.gui import ensure_management_ui_thread, update_activation_progress
+
+        ensure_management_ui_thread()
+        enqueue_management_task(update_activation_progress, progress, elapsed, eta)
+    except Exception:
+        logger.exception("Failed to schedule activation popup progress update")
+
 def format_exception_details(exc: Exception) -> str:
     return "".join(traceback.format_exception_only(type(exc), exc)).strip()
 


### PR DESCRIPTION
## Summary
- correct the small model's expected download size and make the progress bar operate on percentage values for smoother updates
- add an activation progress monitor that tracks the staging folder size to produce percent, runtime, and ETA updates during model activation
- extend the activation popup UI to show a determinate progress bar and status text fed from background updates

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0d2ed9a84832a962851630bbdc42f