### PR TITLE
Improve activation and download UI responsiveness

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -351,6 +351,14 @@ def close_activation_popup(message: Optional[str] = None) -> None:
         except Exception:
             logger.exception("Failed to schedule activation popup dismissal")
             _destroy_busy_popup()
+        else:
+            def _ensure_close() -> None:
+                _call_on_management_ui(
+                    _destroy_busy_popup,
+                    log_message="Failed to destroy activation popup after timeout",
+                )
+
+            threading.Timer(3.2, _ensure_close).start()
     else:
         _destroy_busy_popup()
 # -------- Voice Waveform Overlay --------

--- a/utils/models.py
+++ b/utils/models.py
@@ -614,14 +614,17 @@ def download_model_with_gui(
 
             def monitor_download() -> None:
                 last_reported = -1.0
+                last_emitted = 0.0
                 total_value = float(expected_total) if expected_total else 0.0
                 while True:
                     current_size = float(_measure_directory_size(store_path))
                     if expected_total:
                         current_size = min(current_size, float(expected_total))
-                    if current_size != last_reported:
+                    now = time.monotonic()
+                    if current_size != last_reported or (now - last_emitted) >= 2.0:
                         progress_queue.put(("progress", "", current_size, total_value, True))
                         last_reported = current_size
+                        last_emitted = now
                     if monitor_stop.wait(1.0):
                         break
 


### PR DESCRIPTION
## Summary
- keep the model download dialog updating by emitting periodic progress refreshes even when byte counts stall
- add a timed fallback to ensure the activation completion popup always dismisses itself

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68d0e80f736c832a8ecc8e7d8b8e4fe1