### PR TITLE
Restrict pytest discovery to project tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,23 @@
 [pytest]
+minversion = 8.0
+# Only collect tests from our repository's suite.
+testpaths = tests
+
+# Avoid descending into virtual environments or build artifacts.
+norecursedirs =
+    Lib
+    lib
+    site-packages
+    venv
+    .venv
+    env
+    .env
+    Scripts
+    build
+    dist
+
 markers =
     core_headless: fast, GUI-free tests that run without model downloads.
     full_gui: integration tests that exercise the GUI/server/model stack.
+
 addopts = -ra

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -11,6 +11,9 @@ GUI- and model-heavy integration checks.
   ```bash
   python -m pytest -m core_headless
   ```
+  Pytest is configured (via `pytest.ini`) to only discover tests inside this
+  repository's `tests/` folder so the command works even inside a virtual
+  environment without tripping over third-party packages.
 * **Expected runtime:** a few seconds.
 * **Intended environments:** any developer workstation or CI runner (Linux,
   macOS, or Windows) without GPU/audio dependencies.


### PR DESCRIPTION
## Summary
- limit pytest collection to the repository test suite and ignore common virtualenv directories
- document in TESTING.md that pytest is scoped to the tests folder to avoid third-party collection issues

## Testing
- python -m pytest -m core_headless

------
https://chatgpt.com/codex/tasks/task_e_68d182fc89b8832a958c59cca502b5f1