### PR TITLE
Reorder input audio device section

### DIFF
--- a/utils/config_paths.py
+++ b/utils/config_paths.py
@@ -23,6 +23,7 @@ DEFAULT_SETTINGS: Dict[str, object] = {
     "preferred_server_host": None,
     "preferred_server_port": None,
     "device_preference": "cpu",
+    "input_device": None,
     "model_name": "small",
 }
 


### PR DESCRIPTION
## Summary
- add a persisted input audio device preference to the settings helpers
- resolve and honor the preferred microphone when recording audio
- expose microphone selection and refresh controls in the management window UI
- position the input audio device section below the speech model controls in the management window

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25d1a38c4832a964abd636ff207c8