### PR TITLE
Improve logging configuration and coverage

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import sys
 import atexit
 import time
 
+from utils.config_paths import get_logger
 from utils.system import (
     APP_VERSION,
     SPLASH_DURATION_MS,
@@ -28,70 +29,94 @@ from utils.models import (
     ensure_initial_model_installation,
 )
 
+logger = get_logger(__name__)
+
 
 def main(argv: list[str]) -> int:
+    logger.info("CtrlSpeak starting up (version %s)", APP_VERSION)
     args = parse_cli_args(argv)
+    logger.debug("Parsed CLI arguments: %s", args)
 
     if args.uninstall:
+        logger.info("Uninstall flag detected; launching uninstall workflow")
         from utils.system import initiate_self_uninstall
         initiate_self_uninstall(None)
         return 0
 
     if args.force_sendinput:
+        logger.info("Force SendInput mode enabled via CLI")
         from utils.system import set_force_sendinput
         set_force_sendinput(True)
 
     if args.automation_flow:
+        logger.info("Starting automation flow from CLI request")
         from utils.automation import run_automation_flow
         return run_automation_flow()
 
     # Single instance
     if not acquire_single_instance_lock():
+        logger.warning("Another CtrlSpeak instance appears to be running; exiting")
         notify("CtrlSpeak is already running.")
         return 0
 
     # Load settings early
+    logger.info("Loading configuration settings")
     load_settings()
 
     if args.auto_setup:
+        logger.info("Applying auto-setup profile: %s", args.auto_setup)
         apply_auto_setup(args.auto_setup)
 
     # CLI: offline transcription of a file
     if args.transcribe:
+        logger.info("Running CLI transcription for %s", args.transcribe)
         return transcribe_cli(args.transcribe)
 
     # Splash
+    logger.debug("Displaying splash screen for %sms", SPLASH_DURATION_MS)
     show_splash_screen(SPLASH_DURATION_MS)
 
     # Prepare the shared management UI root before any background tasks need it
+    logger.debug("Ensuring management UI thread is initialized")
     ensure_management_ui_thread()
 
     # Ensure mode selected (client or client_server)
+    logger.debug("Ensuring operating mode is selected")
     ensure_mode_selected()
 
     # Auto-install the default speech model on first launch
     if not ensure_initial_model_installation():
+        logger.error("Initial model installation failed or was aborted")
         return 0
 
     # Determine the selected mode now that setup is complete
     with settings_lock:
         mode = settings.get("mode")
+    logger.info("CtrlSpeak running in '%s' mode", mode)
 
     # Automatically prepare local transcription assets when running the server locally
     if mode == "client_server":
+        logger.info("Preparing local transcription assets for server mode")
         if not ensure_model_ready_for_local_server():
+            logger.error("Failed to prepare local model for server mode")
             return 0
 
     # Start discovery listener for client mode visibility
+    logger.debug("Starting discovery listener")
     start_discovery_listener()
 
     if mode == "client_server":
+        logger.info("Initializing transcriber in background for warm-up")
         initialize_transcriber(interactive=False)   # warm-up local model when assets are ready
+        logger.info("Starting local transcription server")
         start_server()
     elif mode == "client":
+        logger.debug("Client mode selected; allowing discovery broadcast to populate")
         time.sleep(1.0)  # small delay so discovery has time to populate
 
+    logger.info("Launching system tray UI")
     run_tray()
+    logger.info("CtrlSpeak shutting down cleanly")
     return 0
 
 

--- a/utils/config_paths.py
+++ b/utils/config_paths.py
@@ -121,11 +121,12 @@ def asset_path(relative_name: str) -> Path:
 
 LOGGER_NAME = "ctrlspeak"
 _LOG_HANDLER: Optional[RotatingFileHandler] = None
+_CONSOLE_HANDLER: Optional[logging.Handler] = None
 _LOG_CONFIG_LOCK = threading.Lock()
 
 
 def _configure_logging() -> logging.Logger:
-    global _LOG_HANDLER
+    global _LOG_HANDLER, _CONSOLE_HANDLER
 
     with _LOG_CONFIG_LOCK:
         ctrl_logger = logging.getLogger(LOGGER_NAME)
@@ -139,12 +140,20 @@ def _configure_logging() -> logging.Logger:
             )
             formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
             handler.setFormatter(formatter)
+            handler.setLevel(logging.DEBUG)
             _LOG_HANDLER = handler
 
             root_logger = logging.getLogger()
             root_logger.addHandler(handler)
             if root_logger.level == logging.NOTSET or root_logger.level > logging.INFO:
                 root_logger.setLevel(logging.INFO)
+
+            if _CONSOLE_HANDLER is None:
+                console_handler = logging.StreamHandler()
+                console_handler.setLevel(logging.WARNING)
+                console_handler.setFormatter(formatter)
+                root_logger.addHandler(console_handler)
+                _CONSOLE_HANDLER = console_handler
 
             logging.captureWarnings(True)
 

--- a/utils/system.py
+++ b/utils/system.py
@@ -804,37 +804,55 @@ discovery_query_stop_event = threading.Event()
 def start_server() -> None:
     global server_thread, server_httpd, discovery_broadcaster, discovery_query_listener, discovery_query_stop_event, last_connected_server
     if CLIENT_ONLY_BUILD:
+        logger.warning("Server start requested, but this build is client-only")
         notify("Server functionality is not available in this build."); return
-    if server_thread and server_thread.is_alive(): return
+    if server_thread and server_thread.is_alive():
+        logger.debug("Server start requested but server thread is already running")
+        return
     with settings_lock:
         port = int(settings.get("server_port", 65432))
         discovery_port = int(settings.get("discovery_port", 54330))
+    logger.info("Starting CtrlSpeak server on port %s (discovery %s)", port, discovery_port)
     try:
         server_httpd = ThreadingHTTPServer(("0.0.0.0", port), TranscriptionRequestHandler)
     except OSError as exc:
+        logger.error("Server startup failed on port %s: %s", port, exc)
         notify_error("Server startup failed", str(exc)); server_httpd = None; return
     def serve():
-        try: server_httpd.serve_forever()
-        except Exception as exc: notify_error("Server stopped", format_exception_details(exc))
+        try:
+            server_httpd.serve_forever()
+        except Exception as exc:
+            notify_error("Server stopped", format_exception_details(exc))
     server_thread = threading.Thread(target=serve, daemon=True); server_thread.start()
 
     broadcast_stop_event.clear(); discovery_query_stop_event.clear()
-    discovery_broadcaster = threading.Thread(target=manage_discovery_broadcast,
-                                             args=(broadcast_stop_event, discovery_port, port), daemon=True)
+    discovery_broadcaster = threading.Thread(
+        target=manage_discovery_broadcast,
+        args=(broadcast_stop_event, discovery_port, port),
+        daemon=True,
+    )
     discovery_broadcaster.start()
-    discovery_query_listener = threading.Thread(target=listen_for_discovery_queries,
-                                                args=(discovery_query_stop_event, discovery_port, port), daemon=True)
+    discovery_query_listener = threading.Thread(
+        target=listen_for_discovery_queries,
+        args=(discovery_query_stop_event, discovery_port, port),
+        daemon=True,
+    )
     discovery_query_listener.start()
     last_connected_server = ServerInfo(host=get_advertised_host_ip(), port=port, last_seen=time.time())
+    logger.info("CtrlSpeak server listening on port %s", port)
     print(f"CtrlSpeak server listening on port {port}")
     schedule_management_refresh()
 
+
 def shutdown_server() -> None:
     global server_thread, server_httpd, discovery_broadcaster, discovery_query_listener, broadcast_stop_event, discovery_query_stop_event, last_connected_server
+    logger.info("Shutting down CtrlSpeak server")
     broadcast_stop_event.set(); discovery_query_stop_event.set()
-    if discovery_broadcaster and discovery_broadcaster.is_alive(): discovery_broadcaster.join(timeout=1.0)
+    if discovery_broadcaster and discovery_broadcaster.is_alive():
+        discovery_broadcaster.join(timeout=1.0)
     discovery_broadcaster = None
-    if discovery_query_listener and discovery_query_listener.is_alive(): discovery_query_listener.join(timeout=1.0)
+    if discovery_query_listener and discovery_query_listener.is_alive():
+        discovery_query_listener.join(timeout=1.0)
     discovery_query_listener = None
     if server_httpd is not None:
         try:
@@ -842,11 +860,14 @@ def shutdown_server() -> None:
         except Exception:
             logger.exception("Failed to shut down server HTTP listener cleanly")
     server_httpd = None
-    if server_thread and server_thread.is_alive(): server_thread.join(timeout=1.0)
+    if server_thread and server_thread.is_alive():
+        server_thread.join(timeout=1.0)
     server_thread = None
     broadcast_stop_event = threading.Event(); discovery_query_stop_event = threading.Event()
     last_connected_server = None
+    logger.debug("Server resources cleared")
     schedule_management_refresh()
+
 
 # local wrapper to restore original side-effects
 def register_manual_server(host: str, port: int, update_preference: bool = True) -> ServerInfo:
@@ -922,6 +943,7 @@ def run_tray():
 def acquire_single_instance_lock() -> bool:
     global instance_lock_handle
     lock_path = get_config_dir() / LOCK_FILENAME
+    logger.debug("Attempting to acquire instance lock at %s", lock_path)
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
     except Exception:
@@ -929,22 +951,29 @@ def acquire_single_instance_lock() -> bool:
     try:
         handle = open(lock_path, 'a+')
     except OSError as exc:
+        logger.warning("Unable to open lock file at %s: %s", lock_path, exc)
         print(f'Unable to open lock file: {exc}'); return False
     try:
         handle.seek(0)
         if sys.platform.startswith('win'):
             import msvcrt
-            try: msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
             except OSError:
+                logger.info("Instance lock already held by another process (Windows)")
                 handle.close(); return False
         else:
             import fcntl
-            try: fcntl.lockf(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                fcntl.lockf(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError:
+                logger.info("Instance lock already held by another process (POSIX)")
                 handle.close(); return False
         handle.truncate(0); handle.write(str(os.getpid())); handle.flush()
+        logger.info("Acquired instance lock with PID %s", os.getpid())
         instance_lock_handle = handle; return True
     except Exception as exc:
+        logger.error("Unable to acquire single-instance lock: %s", exc)
         print(f'Unable to acquire single-instance lock: {exc}')
         try:
             handle.close()
@@ -955,7 +984,9 @@ def acquire_single_instance_lock() -> bool:
 def release_single_instance_lock() -> None:
     global instance_lock_handle
     handle = instance_lock_handle
-    if handle is None: return
+    if handle is None:
+        logger.debug("Release instance lock requested but no lock handle is present")
+        return
     instance_lock_handle = None
     try:
         if sys.platform.startswith('win'):
@@ -979,6 +1010,7 @@ def release_single_instance_lock() -> None:
             (get_config_dir() / LOCK_FILENAME).unlink(missing_ok=True)
         except Exception:
             logger.exception("Failed to remove instance lock file")
+        logger.info("Released instance lock")
 
 # ---------------- Uninstall ----------------
 def build_uninstall_script(executable: Path, config_dir: Path) -> Path:
@@ -1016,23 +1048,31 @@ def initiate_self_uninstall(icon: Optional[pystray.Icon]) -> None:
 def start_discovery_listener() -> None:
     global discovery_listener
     if discovery_listener is not None and discovery_listener.is_alive():
+        logger.debug(
+            "Discovery listener already active on port %s",
+            getattr(discovery_listener, "port", "unknown"),
+        )
         return
     with settings_lock:
         port = int(settings.get("discovery_port", 54330))
+    logger.info("Starting discovery listener on UDP port %s", port)
     discovery_listener = DiscoveryListener(port); discovery_listener.start()
 
 def stop_discovery_listener() -> None:
     global discovery_listener
     if discovery_listener is None:
+        logger.debug("Discovery listener stop requested but no listener was running")
         return
     try:
         discovery_listener.stop()
     except Exception:
         logger.exception("Failed to stop discovery listener")
     finally:
+        logger.info("Discovery listener stopped")
         discovery_listener = None
 
 def shutdown_all():
+    logger.info("Shutting down all CtrlSpeak services")
     stop_client_listener(); shutdown_server()
     try:
         stop_discovery_listener()


### PR DESCRIPTION
## Summary
- route all logging through the shared logger with a rotating file handler in the application data directory and add a console handler that mirrors warnings and higher
- add lifecycle logging in the application entry point so startup, configuration, and shutdown are captured at info/debug levels
- expand logging in system utilities to trace discovery listener state, server lifecycle, and single-instance locking outcomes

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d45076ca88832ab22212a94d291201