### PR TITLE
Enable Assistant bot screenshot capture

### DIFF
--- a/docs/bot_integration.md
+++ b/docs/bot_integration.md
@@ -85,7 +85,9 @@ Each option also has a matching CLI flag in `third_party/social_robot/main.py` (
 
 ## Screenshot workflow
 
-When you launch the **Assistant** identity from the management UI and say “look at my screen,” SocialRobot now captures the current desktop, stores a PNG copy under the identity’s `memory/screenshots` directory, and forwards the encoded image to the configured Ollama model. The spoken request is automatically augmented with a clarification asking the model to describe the screenshot, so multimodal checkpoints such as `llava:13b` can respond with contextual commentary. If the capture fails (for example, when `pyautogui` cannot access the display), the bot logs the issue and continues as a text-only exchange.
+When you launch the **Assistant** identity from the management UI and say “look at my screen,” SocialRobot now captures the current desktop, stores a PNG copy under the identity’s `memory/screenshots` directory, and forwards the encoded image to the configured Ollama model. The spoken request is automatically augmented with a clarification asking the model to describe the screenshot, so multimodal checkpoints such as `gemma3:12b` can respond with contextual commentary. If the capture fails (for example, when `pyautogui` cannot access the display), the bot logs the issue and continues as a text-only exchange.
+
+As soon as you pick an identity, CtrlSpeak now pings the configured Ollama endpoint with that profile’s model so the checkpoint is fully loaded before you speak. This avoids the first-turn lag that previously occurred while Ollama initialized the weights after receiving the initial utterance.
 
 ## GUI Workflow
 

--- a/docs/bot_integration.md
+++ b/docs/bot_integration.md
@@ -83,6 +83,10 @@ The helper reuses an existing server when you pass `stt_url=...`, and you can fo
 
 Each option also has a matching CLI flag in `third_party/social_robot/main.py` (for example `--identity`, `--prompt-file`, `--system-prompt`, `--memory-dir`).
 
+## Screenshot workflow
+
+When you launch the **Assistant** identity from the management UI and say “look at my screen,” SocialRobot now captures the current desktop, stores a PNG copy under the identity’s `memory/screenshots` directory, and forwards the encoded image to the configured Ollama model. The spoken request is automatically augmented with a clarification asking the model to describe the screenshot, so multimodal checkpoints such as `llava:13b` can respond with contextual commentary. If the capture fails (for example, when `pyautogui` cannot access the display), the bot logs the issue and continues as a text-only exchange.
+
 ## GUI Workflow
 
 1. Start CtrlSpeak in Client + Server mode.

--- a/third_party/social_robot/identities/assistant/identity.json
+++ b/third_party/social_robot/identities/assistant/identity.json
@@ -5,7 +5,7 @@
   "prompt_file": "system_prompt.txt",
   "animation_style": "logo",
   "logo_image": "TrueAI_Logo_Transparent_Final.png",
-  "llm_model": "llava:13b",
+  "llm_model": "gemma3:12b",
   "llm_url": "http://localhost:11434/api/chat",
   "voice": "af_sky",
   "memory_dir": "memory"

--- a/third_party/social_robot/identities/assistant/identity.json
+++ b/third_party/social_robot/identities/assistant/identity.json
@@ -5,7 +5,7 @@
   "prompt_file": "system_prompt.txt",
   "animation_style": "logo",
   "logo_image": "TrueAI_Logo_Transparent_Final.png",
-  "llm_model": "gemma3:1b",
+  "llm_model": "llava:13b",
   "llm_url": "http://localhost:11434/api/chat",
   "voice": "af_sky",
   "memory_dir": "memory"

--- a/third_party/social_robot/llm/ollama.py
+++ b/third_party/social_robot/llm/ollama.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import requests
 
@@ -21,13 +21,22 @@ class OllamaClient:
         self.stream = stream
         self.system_prompt = system_prompt
 
-    def _build_messages(self, user_text: str, history: Optional[List[dict]] = None) -> List[dict]:
+    def _normalize_history_entry(self, entry: dict) -> dict:
+        role = entry.get("role", "user")
+        content = entry.get("content", "")
+        return {"role": role, "content": content}
+
+    def _build_messages(
+        self,
+        user_payload: Any,
+        history: Optional[List[dict]] = None,
+    ) -> List[dict]:
         messages: List[dict] = []
-        if history:
-            messages.extend(history)
         if self.system_prompt:
             messages.append({"role": "system", "content": self.system_prompt})
-        messages.append({"role": "user", "content": user_text})
+        if history:
+            messages.extend(self._normalize_history_entry(item) for item in history)
+        messages.append({"role": "user", "content": user_payload})
         return messages
 
     def _fallback_response(self, user_text: str, stream: bool, error: Exception | None = None):
@@ -49,11 +58,18 @@ class OllamaClient:
         except Exception as exc:
             print(f"-> Failed to request Ollama to unload model: {exc}")
 
-    def query(self, user_text: str, stream: Optional[bool] = None, history: Optional[List[dict]] = None):
+    def query(
+        self,
+        user_text: str,
+        stream: Optional[bool] = None,
+        history: Optional[List[dict]] = None,
+        content: Any | None = None,
+    ):
         use_stream = self.stream if stream is None else stream
+        user_payload = content if content is not None else user_text
         payload = {
             "model": self.model,
-            "messages": self._build_messages(user_text, history=history),
+            "messages": self._build_messages(user_payload, history=history),
             "stream": use_stream,
         }
         print("-> Sending user text to Ollama:\n", user_text)

--- a/third_party/social_robot/main.py
+++ b/third_party/social_robot/main.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import io
 import json
 import os
 import sys
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, List
 
@@ -266,6 +269,44 @@ def main():
     vad_listener: Optional[VADListener] = None
     last_bot_response: str = ""
 
+    def _capture_screenshot() -> tuple[Optional[str], Optional[Path]]:
+        try:
+            import pyautogui  # Local import to avoid heavy dependency on startup
+        except Exception as exc:
+            print(f"-> Screenshot capture unavailable: {exc}")
+            return None, None
+
+        try:
+            image = pyautogui.screenshot()
+        except Exception as exc:
+            print(f"-> Failed to capture screenshot: {exc}")
+            return None, None
+
+        buffer = io.BytesIO()
+        try:
+            image.save(buffer, format="PNG")
+        except Exception as exc:
+            print(f"-> Failed to encode screenshot: {exc}")
+            return None, None
+
+        screenshot_bytes = buffer.getvalue()
+        image_b64 = base64.b64encode(screenshot_bytes).decode("ascii")
+
+        saved_path: Optional[Path] = None
+        if profile.memory_path:
+            try:
+                screenshot_dir = profile.memory_path / "screenshots"
+                screenshot_dir.mkdir(parents=True, exist_ok=True)
+                timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+                saved_path = screenshot_dir / f"screenshot_{timestamp}.png"
+                saved_path.write_bytes(screenshot_bytes)
+            except Exception as exc:
+                print(f"-> Failed to persist screenshot to disk: {exc}")
+                saved_path = None
+
+        print("-> Captured screenshot for analysis.")
+        return image_b64, saved_path
+
     def on_speech_detected(raw_bytes: bytes) -> None:
         nonlocal vad_listener, last_bot_response
         if vad_listener is None: return
@@ -293,13 +334,43 @@ def main():
             animator.update_amplitude(0.0)
             return
 
+        screenshot_b64: Optional[str] = None
+        screenshot_path: Optional[Path] = None
+        augmented_text = recognized_text
+
+        if "look at my screen" in normalized_user:
+            screenshot_b64, screenshot_path = _capture_screenshot()
+            if screenshot_b64:
+                prompt_suffix = "Please describe the attached screenshot and let me know anything important you notice."
+                if augmented_text.strip():
+                    augmented_text = f"{augmented_text.strip()}\n\n{prompt_suffix}"
+                else:
+                    augmented_text = prompt_suffix
+            else:
+                print("-> Proceeding without screenshot due to capture failure.")
+
         history = load_history(profile.memory_path)
-        llm_response = ollama_client.query(recognized_text, history=history)
+
+        user_content: Optional[List[dict]] = None
+        if screenshot_b64:
+            user_content = [
+                {"type": "text", "text": augmented_text},
+                {"type": "image", "image": screenshot_b64},
+            ]
+        llm_response = ollama_client.query(augmented_text, history=history, content=user_content)
         if not llm_response.strip():
             animator.update_amplitude(0.0)
             return
 
-        history.append({"role": "user", "content": recognized_text})
+        history_entry: dict
+        if user_content is not None:
+            history_entry = {"role": "user", "content": user_content}
+            if screenshot_path:
+                history_entry["metadata"] = {"screenshot_file": str(screenshot_path)}
+        else:
+            history_entry = {"role": "user", "content": recognized_text}
+
+        history.append(history_entry)
         history.append({"role": "assistant", "content": llm_response})
         save_history(profile.memory_path, history)
 

--- a/utils/bot_integration.py
+++ b/utils/bot_integration.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
+import json
 import os
 import sys
 import time
 import subprocess
 from pathlib import Path
 from typing import Optional
+
+import requests
 
 from utils.config_paths import get_logger
 from utils.system import (
@@ -55,6 +58,60 @@ def _resolve_stt_url() -> Optional[str]:
         return None
 
 
+def _load_identity_llm_config(identity: str, identities_root: Path) -> tuple[Optional[str], Optional[str]]:
+    config_path = identities_root / identity / "identity.json"
+    if not config_path.exists():
+        return None, None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.exception("Failed to parse identity configuration for '%s'", identity)
+        return None, None
+    return data.get("llm_url"), data.get("llm_model")
+
+
+def _resolve_llm_settings(
+    *,
+    llm_url: Optional[str],
+    llm_model: Optional[str],
+    identity: Optional[str],
+    identities_root: Path,
+) -> tuple[Optional[str], Optional[str]]:
+    resolved_url = llm_url or os.environ.get("BOT_LLM_URL")
+    resolved_model = llm_model or os.environ.get("BOT_LLM_MODEL")
+    if identity:
+        identity_url, identity_model = _load_identity_llm_config(identity, identities_root)
+        if not resolved_url:
+            resolved_url = identity_url
+        if not resolved_model:
+            resolved_model = identity_model
+    return resolved_url, resolved_model
+
+
+def _warm_ollama_model(llm_url: Optional[str], llm_model: Optional[str]) -> None:
+    if not llm_url or not llm_model:
+        return
+
+    warm_url = llm_url.rstrip("/")
+    if warm_url.endswith("/chat"):
+        warm_url = warm_url[: -len("/chat")]
+    warm_url = f"{warm_url}/generate"
+
+    payload = {
+        "model": llm_model,
+        "prompt": "",
+        "stream": False,
+        "keep_alive": "5m",
+    }
+
+    try:
+        response = requests.post(warm_url, json=payload, timeout=10)
+        response.raise_for_status()
+        logger.info("Preloaded Ollama model %s", llm_model)
+    except Exception:
+        logger.warning("Failed to preload Ollama model %s", llm_model, exc_info=True)
+
+
 def start_bot(
     llm_url: Optional[str] = None,
     llm_model: Optional[str] = None,
@@ -90,6 +147,25 @@ def start_bot(
     if not entry.exists():
         logger.error("SocialRobot entrypoint not found at %s", entry)
         return False
+
+    if identities_dir:
+        identities_root = Path(identities_dir).expanduser()
+        if not identities_root.is_absolute():
+            identities_root = robot_dir / identities_root
+    else:
+        identities_root = robot_dir / "identities"
+    try:
+        identities_root = identities_root.resolve()
+    except FileNotFoundError:
+        pass
+
+    resolved_llm_url, resolved_llm_model = _resolve_llm_settings(
+        llm_url=llm_url,
+        llm_model=llm_model,
+        identity=identity,
+        identities_root=identities_root,
+    )
+    _warm_ollama_model(resolved_llm_url, resolved_llm_model)
 
     env = os.environ.copy()
     env["CTRLSPEAK_STT_URL"] = stt_url
@@ -204,6 +280,25 @@ def run_bot_test(
     if not entry.exists():
         logger.error("SocialRobot entrypoint not found at %s", entry)
         return "Error: SocialRobot entrypoint not found."
+
+    if identities_dir:
+        identities_root = Path(identities_dir).expanduser()
+        if not identities_root.is_absolute():
+            identities_root = robot_dir / identities_root
+    else:
+        identities_root = robot_dir / "identities"
+    try:
+        identities_root = identities_root.resolve()
+    except FileNotFoundError:
+        pass
+
+    resolved_llm_url, resolved_llm_model = _resolve_llm_settings(
+        llm_url=llm_url,
+        llm_model=llm_model,
+        identity=identity,
+        identities_root=identities_root,
+    )
+    _warm_ollama_model(resolved_llm_url, resolved_llm_model)
 
     env = os.environ.copy()
     env["CTRLSPEAK_STT_URL"] = stt_url

--- a/utils/system.py
+++ b/utils/system.py
@@ -1002,6 +1002,9 @@ def acquire_single_instance_lock() -> bool:
     global instance_lock_handle
     lock_path = get_config_dir() / LOCK_FILENAME
     logger.debug("Attempting to acquire instance lock at %s", lock_path)
+    if instance_lock_handle is not None:
+        logger.debug("Instance lock already held by current process")
+        return False
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
     except Exception:


### PR DESCRIPTION
## Summary
- detect the "look at my screen" wake phrase, capture the current desktop, and forward the encoded image alongside the user turn
- extend the Ollama client and conversation history to support multimodal content and update the Assistant identity to target an image-capable model
- document the screenshot workflow and prevent reacquiring the single-instance lock inside the same process

## Testing
- python -m compileall .
- python -m pytest -m core_headless


------
https://chatgpt.com/codex/tasks/task_e_68d9c863bfe4832a8c9d82a78c6c38c1