### PR TITLE
Add project TODO backlog documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ After updates you can re-run `--auto-setup client_server` to refresh the install
 - Temporary recordings, configuration, logs, and downloaded Whisper models live under `%APPDATA%\CtrlSpeak`.
 - Test audio files such as `part1.wav` are intentionally excluded from Git to avoid large binaries.
 - Use the tray menu to manage the client/server lifecycle or to uninstall (`Delete CtrlSpeak`).
+- Track future enhancements in [`docs/TODO.md`](docs/TODO.md); keep the list current as tasks are added or completed.
 
 ## Automation Flow
 

--- a/docs/PROJECT_GROUND_RULES.md
+++ b/docs/PROJECT_GROUND_RULES.md
@@ -54,6 +54,7 @@
 
 ## Documentation synchronization
 - When code changes alter behavior, configuration, or user interaction, update the relevant Markdown documentation (`README.md`, files in `docs/`, `tests/TESTING.md`, etc.) in the same change set.
+- Maintain the running backlog in [`docs/TODO.md`](TODO.md) so pending enhancements stay discoverable and current.
 - This ground-rules document sets the guardrails those updates must respect; do not rewrite history to relax these requirements.
 
 Adhering to this reference protects packaging constraints, logging visibility, client/server interoperability, UI stability, and operational readiness. Any change that conflicts with these principles must be redesigned until it complies.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,10 @@
+# CtrlSpeak Developer TODO
+
+This living backlog tracks follow-up work the developer wants to schedule for CtrlSpeak. Update it whenever new ideas surface or when items are completed.
+
+## Pending Work
+- Add a "look at my cursor" / "look at my mouse" keyword that captures a 640×480 image centered on the cursor and passes it to the assistant agent.
+- Gate cursor- and vision-related keywords so they only trigger when the active assistant has vision capabilities.
+- Integrate a Quen3 model with tooling support, starting with Gemini CLI interactions and web search actions.
+- Build a parsing tool that can read local files to gather contextual information for the assistant.
+


### PR DESCRIPTION
## Summary
- add docs/TODO.md to track pending enhancements requested by the developer
- reference the new backlog in the README and project ground rules to keep documentation aligned

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db58905eec832ab49f8ec9cc89ca43