### PR TITLE
Add identity-controlled TTS cleaning toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Both flavours support Windows 10/11, enforce a single running instance, expose a
 ## Repository Layout
 
 - `main.py` – application entry point.
-- `background_agents/` – self-contained helpers that run alongside Chat with Bot. The bundled `tts_preprocessing_agent` rewrites LLM replies before Kokoro speaks them.
+- `background_agents/` – self-contained helpers that run alongside Chat with Bot. The bundled `tts_preprocessing_agent` rewrites LLM replies before Kokoro speaks them when an identity opts into text cleaning.
 - `assets/` – static resources such as the tray icon (`icon.ico`), the welcome video (`TrueAI_Intro_Video.mp4`), the fun-fact rotation list (`fun_facts.txt`), and the processing chime (`loading.wav`).
 - `utils/` – implementation modules (GUI, models, networking, configuration helpers, etc.).
 - `utils/build_exe.py` – helper script that runs PyInstaller with the correct data files.
@@ -53,7 +53,7 @@ Run `python main.py --help` for the full list.
 
 ### Chat with Bot speech pipeline
 
-When you launch **Chat with Bot**, the LLM reply is routed through `background_agents/tts_preprocessing_agent` before Kokoro generates speech. The helper reads `identity.json` to decide whether to prepend `header_text.txt`, supply `system_prompt.txt`, or do both based on the `preamble` setting (`header`, `system`, or `both`, with the agent defaulting to `both`). That instruction set asks Gemma 3 1B to smooth the phrasing for text-to-speech and returns the rewritten script. Adjust the files referenced in `identity.json` to tune how aggressively responses are reformatted. If the agent fails or the directory is missing, CtrlSpeak falls back to speaking the original reply so conversations continue uninterrupted.
+When you launch **Chat with Bot**, identities that set `require_text_cleaning: true` in their `identity.json` route the LLM reply through `background_agents/tts_preprocessing_agent` before Kokoro generates speech. The helper reads its own configuration to decide whether to prepend `header_text.txt`, supply `system_prompt.txt`, or do both based on the `preamble` setting (`header`, `system`, or `both`, with the agent defaulting to `both`). That instruction set asks Gemma 3 1B to smooth the phrasing for text-to-speech and returns the rewritten script. Identities with `require_text_cleaning: false` hand their responses directly to Kokoro. If the agent fails or the directory is missing, CtrlSpeak falls back to speaking the original reply so conversations continue uninterrupted.
 
 Voice keywords live in [`tools/keywords.py`](docs/tooling.md). Saying “look at my screen” or “look at my clipboard” captures an image via the shared vision tooling, “chat with <identity>” (for example, assistant or default) relaunches the bot with that persona unless it is already active, and “goodbye <identity>” stops the current conversation immediately.
 

--- a/docs/bot_integration.md
+++ b/docs/bot_integration.md
@@ -4,7 +4,7 @@ CtrlSpeak includes an optional "Chat with Bot" experience accessible from the ma
 
 - **Speech to Text (STT)** - Uses CtrlSpeak's `/transcribe` endpoint. Audio captured by the VAD listener is sent to the running CtrlSpeak server (local or remote depending on mode). The server returns the recognized text.
 - **Language Model (LLM)** - The recognized text is sent to the Ollama-compatible client inside SocialRobot. By default CtrlSpeak ships with a lightweight fallback response if no LLM endpoint is reachable, but you can supply your own by setting the `BOT_LLM_URL` and `BOT_LLM_MODEL` environment variables (or the matching CLI flags) before launching CtrlSpeak.
-- **Speech rewrite (background agent)** - The LLM reply is routed through `background_agents/tts_preprocessing_agent`, which consults its `identity.json` to determine whether to prepend `header_text.txt`, load `system_prompt.txt`, or use both before sending the request to the Gemma 3 1B preprocessing helper. The agent rewrites the reply for smoother narration before speech is generated.
+- **Speech rewrite (background agent)** - Identities that opt into cleaning route the LLM reply through `background_agents/tts_preprocessing_agent`, which consults its `identity.json` to determine whether to prepend `header_text.txt`, load `system_prompt.txt`, or use both before sending the request to the Gemma 3 1B preprocessing helper. The agent rewrites the reply for smoother narration before speech is generated.
 - **Text to Speech (TTS)** - The LLM response is converted to audio via Kokoro-ONNX. CtrlSpeak defaults to the formal male `am_michael` voice; override it with `BOT_VOICE` or the `--voice` flag.
 - **Animated Face / Logo** - SocialRobot renders the default TrueAI transparent logo with amplitude-based scaling for visual feedback. Identity folders can still supply alternate assets under `third_party/social_robot/identities/<name>` when a different look is desired.
 
@@ -32,6 +32,7 @@ The loader understands the following `identity.json` keys:
     "num_ctx": 8192
   },
   "voice": "am_michael",
+  "require_text_cleaning": false,
   "vision": true,
   "tool": false,
   "memory_dir": "memory"
@@ -48,12 +49,13 @@ When present, `ollama_options` is merged into the payload that SocialRobot sends
 
 CtrlSpeak applies the same options and hardware preference when it pre-warms the checkpoint via `/generate`, ensuring the residency chosen during warm-up matches the settings SocialRobot will use at runtime.
 
-The additional boolean keys control multimodal and future extensibility features:
+The additional boolean keys control multimodal, cleaning, and future extensibility features:
 
+- `require_text_cleaning` – When `true`, SocialRobot loads the TTS preprocessing agent and rewrites replies before speech. When `false`, replies flow directly to Kokoro and CtrlSpeak skips staging the helper model.
 - `vision` – Enables image capture tooling documented in [`docs/tooling.md`](tooling.md). When `true`, SocialRobot listens for the spoken “look at my screen” and “look at my clipboard” commands, exposes matching context-menu actions on the floating logo, and routes captured images to the LLM. When `false`, the commands are ignored, the context-menu items are hidden, and no images are taken.
 - `tool` – Reserved flag for forthcoming external tool integrations. It defaults to `false` today but can be toggled once tool calling is implemented.
 
-CtrlSpeak ships with two bundled identities: `assistant` (vision enabled) and `default` (vision disabled). Both currently set `tool` to `false` and can be expanded as the tool feature matures.
+CtrlSpeak ships with two bundled identities: `assistant` (vision enabled, text cleaning enabled) and `default` (vision disabled, text cleaning disabled). Both currently set `tool` to `false` and can be expanded as the tool feature matures.
 
 You can switch identities from the command line with:
 
@@ -86,7 +88,7 @@ The speech rewrite pass lives under `background_agents/tts_preprocessing_agent`.
 
 `background_agents/tts_preprocessing_agent/background_agent.py` loads these files, constructs a non-streaming `OllamaClient`, and exposes `load_tts_preprocessing_agent()` for the main loop. The `preamble` key in `identity.json` accepts `header`, `system`, or `both` to control which assets are required—missing files for the chosen mode disable the helper so playback still succeeds. If the resources are missing or the helper raises `OllamaUnavailableError`, SocialRobot logs the failure and falls back to the original reply so the session keeps flowing.【F:background_agents/tts_preprocessing_agent/background_agent.py†L1-L199】【F:third_party/social_robot/main.py†L180-L271】
 
-CtrlSpeak treats the agent as a first-class asset: `utils.bot_integration.start_bot` stages the Gemma weights with the same welcome workflow used for identity models and pre-warms the checkpoint once it is available.【F:utils/bot_integration.py†L52-L226】【F:utils/bot_integration.py†L420-L637】 Packaged builds bundle `background_agents/` so the helper is present in single-file executables.【F:packaging/CtrlSpeak.spec†L42-L63】【F:packaging/CtrlSpeak_Watcher.spec†L42-L63】【F:utils/build_exe.py†L22-L82】
+CtrlSpeak treats the agent as a first-class asset for identities that request it: `utils.bot_integration.start_bot` only stages the Gemma weights and pre-warms the checkpoint when the selected identity advertises `require_text_cleaning: true`, skipping the additional download and warm-up otherwise.【F:utils/bot_integration.py†L116-L214】【F:utils/bot_integration.py†L635-L790】 Packaged builds bundle `background_agents/` so the helper is present in single-file executables.【F:packaging/CtrlSpeak.spec†L42-L63】【F:packaging/CtrlSpeak_Watcher.spec†L42-L63】【F:utils/build_exe.py†L22-L82】
 
 ## Runtime Requirements
 

--- a/third_party/social_robot/identities/assistant/identity.json
+++ b/third_party/social_robot/identities/assistant/identity.json
@@ -13,6 +13,7 @@
     "num_ctx": 8192
   },
   "voice": "af_sky",
+  "require_text_cleaning": true,
   "vision": true,
   "tool": false,
   "memory_dir": "memory"

--- a/third_party/social_robot/identities/default/identity.json
+++ b/third_party/social_robot/identities/default/identity.json
@@ -13,6 +13,7 @@
     "num_ctx": 8192
   },
   "voice": "am_michael",
+  "require_text_cleaning": false,
   "vision": false,
   "tool": false,
   "memory_dir": "memory"

--- a/third_party/social_robot/main.py
+++ b/third_party/social_robot/main.py
@@ -66,6 +66,7 @@ class IdentityProfile:
         ollama_hardware: Optional[str] = None,
         vision_enabled: bool = False,
         tool_enabled: bool = False,
+        require_text_cleaning: bool = True,
     ) -> None:
         self.name = name
         self.system_prompt = system_prompt
@@ -78,6 +79,7 @@ class IdentityProfile:
         self.ollama_hardware = ollama_hardware
         self.vision_enabled = vision_enabled
         self.tool_enabled = tool_enabled
+        self.require_text_cleaning = require_text_cleaning
 
 def _resolve_identities_root(arg_value: Optional[str]) -> Path:
     if arg_value:
@@ -194,6 +196,15 @@ def resolve_identity(args) -> tuple[IdentityProfile, dict]:
     else:
         tool_enabled = False
 
+    cleaning_flag = config.get("require_text_cleaning")
+    if isinstance(cleaning_flag, bool):
+        require_text_cleaning = cleaning_flag
+    elif cleaning_flag is not None:
+        print("-> Ignoring require_text_cleaning value; expected a boolean true/false.")
+        require_text_cleaning = True
+    else:
+        require_text_cleaning = True
+
     profile = IdentityProfile(
         name=identity_name,
         system_prompt=system_prompt,
@@ -206,6 +217,7 @@ def resolve_identity(args) -> tuple[IdentityProfile, dict]:
         ollama_hardware=normalized_hardware,
         vision_enabled=vision_enabled,
         tool_enabled=tool_enabled,
+        require_text_cleaning=require_text_cleaning,
     )
 
     print(f"-> Loaded identity '{profile.name}' (voice={profile.voice}, model={profile.llm_model})")
@@ -279,7 +291,13 @@ def main():
     )
 
     tts_model = KokoroTTS(voice=profile.voice, speed=1.0)
-    preprocessing_agent = load_tts_preprocessing_agent()
+    if profile.require_text_cleaning:
+        preprocessing_agent = load_tts_preprocessing_agent()
+        if preprocessing_agent is None:
+            print("-> TTS preprocessing agent unavailable; falling back to raw replies.")
+    else:
+        preprocessing_agent = None
+        print("-> Identity does not require text cleaning; skipping TTS preprocessing agent.")
 
     if args.test_wav:
         import wave

--- a/utils/bot_integration.py
+++ b/utils/bot_integration.py
@@ -123,6 +123,23 @@ def _load_identity_config(identity: str, identities_dir: Optional[str]) -> tuple
     return config, identity_path
 
 
+def _identity_requires_text_cleaning(
+    identity: Optional[str], identities_dir: Optional[str]
+) -> bool:
+    target = _normalized_identity(identity)
+    config, _identity_path = _load_identity_config(target, identities_dir)
+    value = config.get("require_text_cleaning")
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        logger.warning(
+            "Ignoring require_text_cleaning for identity %s; expected boolean but received %r",
+            target,
+            value,
+        )
+    return True
+
+
 def _load_preprocessor_identity() -> tuple[Optional[Path], Optional[str], Optional[str], Dict[str, Any], Optional[str]]:
     agent_dir = _TTS_PREPROCESSOR_DIR
     if not agent_dir.exists():
@@ -697,15 +714,25 @@ def start_bot(
     if not _ensure_identity_llm_ready(identity, identities_dir, llm_model, llm_url):
         return False
 
-    (
-        _agent_dir,
-        agent_llm_url,
-        agent_llm_model,
-        agent_options,
-        agent_hardware,
-    ) = _load_preprocessor_identity()
-    if not _ensure_preprocessor_llm_ready(agent_llm_model, agent_llm_url):
-        return False
+    agent_llm_url: Optional[str] = None
+    agent_llm_model: Optional[str] = None
+    agent_options: Dict[str, Any] = {}
+    agent_hardware: Optional[str] = None
+    if _identity_requires_text_cleaning(target_identity, identities_dir):
+        (
+            _agent_dir,
+            agent_llm_url,
+            agent_llm_model,
+            agent_options,
+            agent_hardware,
+        ) = _load_preprocessor_identity()
+        if not _ensure_preprocessor_llm_ready(agent_llm_model, agent_llm_url):
+            return False
+    else:
+        logger.info(
+            "Identity %s does not require TTS preprocessing; skipping agent preparation",
+            target_identity,
+        )
 
     normalized_base_url: Optional[str] = None
     resolved_model_name: Optional[str] = None


### PR DESCRIPTION
## Summary
- add a require_text_cleaning flag to SocialRobot identities and honor it when loading the TTS preprocessing agent
- skip staging the preprocessing Ollama model in CtrlSpeak when the active persona does not request cleaning
- update bundled identity configs and documentation to explain the new toggle and defaults

## Testing
- PYTHONPATH=. pytest tests/core/test_tts_preprocessing_agent.py


------
https://chatgpt.com/codex/tasks/task_e_68db5aee071c832a8b863a6d918f75c2