### PR TITLE
Add maintenance notes to architecture and threading reports

### DIFF
--- a/reports/software_architecture_report.md
+++ b/reports/software_architecture_report.md
@@ -1,0 +1,37 @@
+# CtrlSpeak Software Architecture Report
+
+## Report Purpose and Maintenance Notes
+This document catalogs the major architectural elements that make CtrlSpeak function as a speech-driven desktop assistant. It
+summarizes execution flow, highlights the responsibilities and interactions of core subsystems, and traces how runtime resources
+are orchestrated across the application. When this report needs to be refreshed or recreated, review the primary entry point in
+`main.py`, configuration helpers under `utils/config_paths.py`, model management logic inside `utils/models.py`, user-interface
+coordination within `utils/gui.py`, automation helpers in `tools/`, and the service orchestration code embedded in `utils/system.py`
+and related background modules. Audit any new packages added under `utils/`, `background_agents/`, or `tools/`, confirm how
+settings and file paths are persisted, and document lifecycle changes for networking or tray management components before
+updating the summaries below.
+
+## Overview
+CtrlSpeak is a Windows-focused speech assistant built around a modular Python codebase. The entry point coordinates startup, configuration, model management, networking, and UI concerns while delegating specialized work to dedicated utility packages and tooling modules.【F:main.py†L42-L195】【F:README.md†L1-L118】 Persistent data, including settings, logs, temporary audio, models, and CUDA assets, is centralized under the application configuration directory so both source and packaged builds share a consistent filesystem contract.【F:utils/config_paths.py†L19-L120】
+
+## Execution Flow
+The `main.main` function processes CLI switches (automation runs, CUDA staging, server-only execution, transcription of existing WAV files), enforces a single instance, loads persisted settings, and performs GPU prerequisite checks before driving the interactive workflow.【F:main.py†L42-L140】 Startup then primes the Tk-based management UI, prompts for client vs. client-server mode, configures voice keyword metadata, ensures the default Whisper model is installed, prepares local transcription assets when hosting the server, launches LAN discovery, and finally hands off to the tray UI to keep the application resident.【F:main.py†L142-L195】
+
+## Core Subsystems
+- **Configuration & Logging:** `utils.config_paths` exposes helpers to resolve the per-user data root, manage the JSON settings file, create temporary recording paths, and configure a rotating file logger shared across modules.【F:utils/config_paths.py†L19-L169】 The module is also the source of the `settings` map and synchronization primitives that gate concurrent updates.
+- **Speech Models:** `utils.models` orchestrates Whisper asset installation, device selection, and runtime initialization. It triggers GUI-guided downloads when model files are missing, records state in settings, selects CPU/GPU compute types, and lazily loads the Whisper model with fallbacks and user notifications for error cases.【F:utils/models.py†L2060-L2305】 All model operations reuse the configuration helpers so download traces, CUDA caches, and staging directories remain under `%APPDATA%\CtrlSpeak`.
+- **System Services:** `utils.system` bundles runtime services—hotkey handling, audio capture, transcription request routing, discovery state, tray lifecycle, and embedded HTTP server hosting. It exposes APIs used by `main.py` and UI code while keeping global state (threads, last-connected server, processing audio feedback, etc.) consistent across the client/server split.【F:utils/system.py†L611-L1389】
+- **GUI Management:** `utils.gui` owns the Tk root, splash, onboarding overlays, management window, and other dialogs. It ensures the root is created and pumped on the main thread while worker threads schedule UI work via a queue, preventing direct Tk calls outside the UI thread.【F:utils/gui.py†L1180-L1309】
+- **Tooling & Keywords:** Keyword detection lives in `tools/keywords.py`, which provides reusable helpers for registering identity-specific phrases and scanning transcripts for automation triggers. `main.py` and both hotkey/server pipelines rely on this module to keep conversation control centralized.【F:tools/keywords.py†L1-L196】【F:main.py†L154-L160】【F:utils/system.py†L685-L920】
+- **Bot Integration:** `utils.bot_integration` manages SocialRobot subprocesses, Ollama model readiness, and monitoring threads so conversational features stay synchronized with transcription services.【F:utils/bot_integration.py†L620-L860】 Background agents under `background_agents/` supplement these flows by preprocessing LLM replies before TTS playback.【F:README.md†L7-L60】
+
+## Networking and Discovery
+Local/remote speech modes share networking primitives implemented in `utils.net_discovery`. A daemon `DiscoveryListener` thread listens for UDP broadcasts, maintains a time-based registry, and exposes helpers to send manual queries, record preferred servers, and probe connectivity.【F:utils/net_discovery.py†L15-L200】 `utils.system` wraps these helpers to update global state, refresh UI descriptions, and bootstrap discovery threads alongside the HTTP transcription server.【F:utils/system.py†L818-L1141】 The HTTP server itself is a `ThreadingHTTPServer` instance that streams uploaded audio to the transcriber, honors keyword interceptors, and responds with JSON payloads.【F:utils/system.py†L1010-L1137】
+
+## User Interface Composition
+The tray icon—started via `utils.system.run_tray`—spawns the keyboard listener, exposes management and quit actions, and runs pystray in a dedicated thread so the Tk management loop can continue on the main thread.【F:utils/system.py†L1188-L1233】 The management UI leverages queued tasks to update server status, initiate downloads, and surface notifications without violating Tk’s single-thread rule.【F:utils/gui.py†L1180-L1309】 Feedback overlays (waveform capture, processing indicators, lockout windows) depend on coordination between `utils.gui`, `utils.system`, and `utils.models` to keep user prompts aligned with background work.【F:utils/system.py†L667-L887】【F:utils/models.py†L2140-L2289】
+
+## Data & Resource Management
+Static assets (icons, audio, onboarding media) are resolved relative to the application base via `utils.config_paths.get_app_base_dir`, ensuring packaged builds locate bundled resources while source runs use the repository layout.【F:utils/config_paths.py†L106-L120】 Runtime assets (temporary recordings, CUDA DLLs, Whisper weights) are staged in the config tree with trace logging so both automation flows and GUI interactions share a common audit trail.【F:utils/models.py†L2060-L2305】【F:README.md†L31-L84】
+
+## Extensibility Considerations
+The architecture isolates platform integrations (audio, clipboard, SendInput) inside `utils.system` and `utils.winio`, preserving a single owner for hotkey handling and text injection. Keyword expansion and additional tooling modules can be added without touching core loops by extending `tools/keywords` and referencing the new payloads in `utils.system`. Model variants, CUDA updates, or automation improvements flow through `utils.models` and `utils.automation`, limiting cross-module coupling and keeping the entry point focused on orchestration.【F:utils/system.py†L611-L1389】【F:tools/keywords.py†L65-L196】【F:utils/models.py†L2060-L2305】

--- a/reports/thread_management_report.md
+++ b/reports/thread_management_report.md
@@ -1,0 +1,35 @@
+# CtrlSpeak Thread Management Report
+
+## Report Purpose and Maintenance Notes
+This report inventories every long-lived and transient thread that CtrlSpeak relies on, explaining how they interact, what
+synchronization primitives guard shared state, and how shutdown sequences avoid race conditions. It is intended to guide future
+audits of concurrency decisions and ensure new workers integrate cleanly with the Tkinter UI loop, audio stack, and background
+services. To regenerate or update this report, inspect the thread creation sites in `utils/system.py`, `utils/gui.py`,
+`utils/net_discovery.py`, `utils/models.py`, and `utils/bot_integration.py`, along with any background helpers under
+`background_agents/`. Confirm the lifecycle of each `Thread`, `Event`, and lock, note new daemon workers or listener loops, and
+verify how teardown joins or signals them before revising the sections below.
+
+## Threading Strategy Overview
+CtrlSpeak uses a mix of long-lived daemon threads, short-lived workers, and the main Tk event loop to compartmentalize I/O, audio, and UI responsibilities. Shared state is guarded by locks, events, and queues defined in `utils.system`, ensuring background activity never touches Tkinter or GUI widgets directly.【F:utils/system.py†L120-L182】【F:utils/system.py†L301-L343】【F:utils.gui.py†L1180-L1309】
+
+## Main/UI Thread
+The Tk root is created and managed on the main thread by `utils.gui`, which records the thread identity, exposes a task queue, and enforces that `pump_management_events_once` only runs on the main thread. Worker code schedules UI work through `enqueue_management_task`, avoiding direct Tk calls from other threads.【F:utils.gui.py†L1180-L1309】【F:utils.system.py†L301-L343】 The pystray loop runs on a separate daemon thread so the main thread can continue servicing Tk events and queued UI callbacks.【F:utils/system.py†L1188-L1233】
+
+## Audio Capture and Feedback Threads
+- **Recording thread:** When the right Ctrl key is pressed, `start_client_listener` spawns a `keyboard.Listener` and, on activation, launches a daemon thread executing `record_audio` to pull microphone frames until the key is released. The main thread waits for the recorder to join before dispatching transcription and cleanup, ensuring orderly teardown.【F:utils/system.py†L846-L887】
+- **Processing loop:** During transcription, `start_processing_feedback` spins up a daemon thread that loops the processing chime, computes RMS levels, and updates shared waveform buffers for the overlay until `processing_sound_stop_event` fires.【F:utils/system.py†L345-L498】
+- **Ready sound worker:** `play_model_ready_sound_once` guards a single-shot worker thread that plays a notification clip without blocking other audio operations.【F:utils/system.py†L500-L534】
+
+## Hotkey Listener and Discovery Refresh
+`start_client_listener` protects listener lifecycle with `listener_lock`, starting the pynput listener and queueing a daemon `_refresh_best_server_async` thread to update discovery state in the background. `stop_client_listener` shuts down the listener, joins any active recording thread, hides GUI overlays, and removes residual files, preventing resource leaks.【F:utils/system.py†L846-L887】
+
+## Networking and Server Threads
+- **Discovery listener:** `utils.net_discovery.DiscoveryListener` subclasses `threading.Thread` to receive UDP broadcasts, prune stale entries, and expose the latest server info. It runs as a daemon and can be stopped via an event flag and socket close.【F:utils/net_discovery.py†L25-L83】 `utils.system.start_discovery_listener` ensures only one instance runs at a time and cleans up via `stop_discovery_listener`.【F:utils/system.py†L1351-L1376】
+- **HTTP server:** `start_server` initializes a `ThreadingHTTPServer`, then launches a daemon thread to call `serve_forever`. Companion daemon threads broadcast presence and listen for discovery queries, all controlled by `threading.Event` objects for cooperative shutdown.【F:utils/system.py†L1094-L1166】
+- **Tray orchestration:** `run_tray` creates the pystray icon and starts it in a daemon thread, while the main thread continues pumping Tk. Shutdown paths stop the listener, server, and UI cleanly.【F:utils/system.py†L1188-L1233】
+
+## Bot and Model Management Threads
+`utils.models.initialize_transcriber` can spawn background work during Whisper initialization (audio feedback, GPU fallbacks) but returns control once the model is ready; it relies on the processing feedback thread for status cues.【F:utils/models.py†L2140-L2289】 When Ollama assets are required, `utils.bot_integration` launches a worker process plus a daemon `OllamaModelMonitor` thread to watch availability and update GUI lockout dialogs.【F:utils/bot_integration.py†L414-L434】 Active SocialRobot sessions are monitored by a daemon `_monitor_bot_exit` thread so the active identity resets immediately when the subprocess terminates.【F:utils/bot_integration.py†L643-L833】
+
+## Synchronization and Shutdown
+Global locks (`listener_lock`, `_processing_level_lock`, `_proc_vis_lock`) and events (`processing_sound_stop_event`, discovery stop events) coordinate shared state across threads.【F:utils/system.py†L120-L182】【F:utils/system.py†L345-L498】【F:utils/system.py†L1094-L1166】 Shutdown helpers invoke these signals, join threads with timeouts, and refresh the management UI so users see accurate status as services stop.【F:utils/system.py†L1094-L1389】


### PR DESCRIPTION
## Summary
- add maintenance and regeneration guidance to the software architecture report
- add maintenance and regeneration guidance to the thread management report

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dba78b3408832a983ad65502625ad0