### PR TITLE
Limit stored vision history to the latest capture

### DIFF
--- a/docs/bot_integration.md
+++ b/docs/bot_integration.md
@@ -151,6 +151,8 @@ When you launch an identity with `vision: true` (for example the bundled **Assis
 
 As soon as you pick an identity, CtrlSpeak now pings the configured Ollama endpoint with that profile’s model so the checkpoint is fully loaded before you speak. This avoids the first-turn lag that previously occurred while Ollama initialized the weights after receiving the initial utterance.
 
+To keep the prompt context small, SocialRobot only retains the **most recent** image payload in the conversation history. When a new screenshot or clipboard capture is added, earlier history entries have their base64 payload removed and are replaced with a short `[previous image removed]` marker so the transcript still notes that a capture occurred without exhausting the model context window.
+
 ## Clearing stored memory
 
 Use the **Clear Bot Memory** button in the management window when you need to wipe a persona’s stored context. After you choose an identity and confirm the prompt, CtrlSpeak removes that profile’s `memory/conversation.json` file and deletes the entire `memory/screenshots` directory so no cached captures remain. If neither artifact exists, the dialog reports that there is nothing to clear.

--- a/tests/core/test_social_robot_history.py
+++ b/tests/core/test_social_robot_history.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+
+SOCIAL_ROBOT_DIR = Path(__file__).resolve().parents[2] / "third_party" / "social_robot"
+import sys
+
+if str(SOCIAL_ROBOT_DIR) not in sys.path:
+    sys.path.insert(0, str(SOCIAL_ROBOT_DIR))
+
+from history_utils import REMOVED_IMAGE_PLACEHOLDER, prune_history_images
+
+
+@pytest.mark.core_headless
+def test_prune_history_images_keeps_latest_image():
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "image", "image": "first_image"},
+            ],
+        },
+        {"role": "assistant", "content": "ack"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "latest"},
+                {"type": "image", "image": "latest_image"},
+            ],
+        },
+    ]
+
+    prune_history_images(history)
+
+    first_entry_content = history[0]["content"]
+    latest_entry_content = history[2]["content"]
+
+    assert all(
+        item.get("type") != "image" for item in first_entry_content if isinstance(item, dict)
+    )
+    assert any(
+        item.get("type") == "image" and item.get("image") == "latest_image"
+        for item in latest_entry_content
+        if isinstance(item, dict)
+    )
+
+
+@pytest.mark.core_headless
+def test_prune_history_images_removes_all_when_requested():
+    history = [
+        {"role": "user", "content": [{"type": "image", "image": "first_image"}]},
+        {"role": "assistant", "content": "ack"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "latest"},
+                {"type": "image", "image": "latest_image"},
+            ],
+        },
+    ]
+
+    prune_history_images(history, keep_latest=False)
+
+    for entry in history:
+        content = entry.get("content")
+        if isinstance(content, list):
+            assert all(
+                item.get("type") != "image"
+                for item in content
+                if isinstance(item, dict)
+            )
+
+    assert history[0]["content"][0]["text"] == REMOVED_IMAGE_PLACEHOLDER

--- a/third_party/social_robot/history_utils.py
+++ b/third_party/social_robot/history_utils.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+REMOVED_IMAGE_PLACEHOLDER = "[previous image removed]"
+
+
+def load_history(memory_path: Optional[Path]) -> List[dict]:
+    if memory_path:
+        history_file = memory_path / "conversation.json"
+        if history_file.exists():
+            try:
+                return json.loads(history_file.read_text(encoding="utf-8"))
+            except Exception as exc:
+                print(f"-> Failed to load conversation history: {exc}")
+    return []
+
+
+def save_history(memory_path: Optional[Path], history: List[dict]) -> None:
+    if memory_path:
+        try:
+            history_file = memory_path / "conversation.json"
+            history_file.write_text(json.dumps(history, indent=2), encoding="utf-8")
+        except Exception as exc:
+            print(f"-> Failed to save conversation history: {exc}")
+
+
+def _entry_contains_image(entry: dict) -> bool:
+    content = entry.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "image" and item.get("image"):
+                return True
+    return False
+
+
+def prune_history_images(history: List[dict], *, keep_latest: bool = True) -> None:
+    """Remove base64 image payloads from all but the most recent vision entry."""
+
+    latest_index: Optional[int] = None
+    if keep_latest:
+        for index in range(len(history) - 1, -1, -1):
+            if _entry_contains_image(history[index]):
+                latest_index = index
+                break
+
+    for index, entry in enumerate(history):
+        content = entry.get("content")
+        if not isinstance(content, list):
+            continue
+
+        new_content: list[dict] = []
+        removed_image = False
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "image":
+                if keep_latest and index == latest_index:
+                    new_content.append(item)
+                else:
+                    removed_image = True
+                continue
+            new_content.append(item)
+
+        if not new_content and removed_image:
+            new_content = [{"type": "text", "text": REMOVED_IMAGE_PLACEHOLDER}]
+        elif removed_image:
+            text_items = [i for i in new_content if isinstance(i, dict) and i.get("type") == "text"]
+            if not text_items:
+                new_content.append({"type": "text", "text": REMOVED_IMAGE_PLACEHOLDER})
+
+        if removed_image:
+            entry["content"] = new_content

--- a/third_party/social_robot/main.py
+++ b/third_party/social_robot/main.py
@@ -27,6 +27,7 @@ from PySide6.QtCore import QTimer
 
 from tools import keywords, vision
 from utils.config_paths import get_logger
+from history_utils import load_history, save_history, prune_history_images
 
 
 logger = get_logger(__name__)
@@ -248,24 +249,6 @@ def parse_args():
     p.add_argument("--memory-dir", default=os.getenv("BOT_MEMORY_DIR"))
     p.add_argument("--test-wav", help="Path to a WAV file to process for testing (bypasses VAD/mic).")
     return p.parse_args()
-
-def load_history(memory_path: Optional[Path]) -> List[dict]:
-    if memory_path:
-        history_file = memory_path / "conversation.json"
-        if history_file.exists():
-            try:
-                return json.loads(history_file.read_text(encoding="utf-8"))
-            except Exception as exc:
-                print(f"-> Failed to load conversation history: {exc}")
-    return []
-
-def save_history(memory_path: Optional[Path], history: List[dict]) -> None:
-    if memory_path:
-        try:
-            history_file = memory_path / "conversation.json"
-            history_file.write_text(json.dumps(history, indent=2), encoding="utf-8")
-        except Exception as exc:
-            print(f"-> Failed to save conversation history: {exc}")
 
 def main():
     args = parse_args()
@@ -678,9 +661,11 @@ def main():
             vision_source = capture_result.source
 
         history = load_history(profile.memory_path)
+        prune_history_images(history)
         try:
             user_content: Optional[List[dict]] = None
             if vision_b64:
+                prune_history_images(history, keep_latest=False)
                 user_content = [
                     {"type": "text", "text": augmented_text},
                     {"type": "image", "image": vision_b64},


### PR DESCRIPTION
## Summary
- extract SocialRobot conversation history helpers into a dedicated module and prune older vision payloads so only the latest image stays in context
- update the screenshot workflow documentation to describe the single-image retention and placeholder marker
- add headless tests covering history pruning behaviour for both retaining and removing prior images

## Testing
- python -m compileall .
- python -m pytest -m core_headless

------
https://chatgpt.com/codex/tasks/task_e_68dbcf845124832aa55343a2ee8cf0b7