### PR TITLE
Refine vector memory retrieval to use scoped Chroma queries

### DIFF
--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 class Collection:
@@ -56,6 +57,50 @@ class Collection:
             payload["metadatas"] = [dict(entry["metadata"]) for _, entry in items]
         if "embeddings" in include:
             payload["embeddings"] = [list(entry["embedding"]) for _, entry in items]
+        return payload
+
+    def query(
+        self,
+        *,
+        query_embeddings: Iterable[Iterable[float]],
+        n_results: int = 10,
+        include: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        include = include or []
+        query_vectors = [list(vector) for vector in query_embeddings]
+        limit = max(0, int(n_results))
+        payload: Dict[str, Any] = {"ids": []}
+        if "documents" in include:
+            payload["documents"] = []
+        if "metadatas" in include:
+            payload["metadatas"] = []
+        if "distances" in include:
+            payload["distances"] = []
+
+        for vector in query_vectors:
+            scored: List[Tuple[float, str, Dict[str, Any]]] = []
+            for entry_id, entry in self._entries.items():
+                metadata = entry.get("metadata") or {}
+                if where and not self._matches_where(metadata, where):
+                    continue
+                embedding = entry.get("embedding") or []
+                if not embedding:
+                    continue
+                similarity = self._cosine_similarity(vector, embedding)
+                distance = 1.0 - similarity
+                scored.append((distance, entry_id, entry))
+            scored.sort(key=lambda item: item[0])
+            top = scored[:limit] if limit else []
+
+            payload["ids"].append([entry_id for _, entry_id, _ in top])
+            if "documents" in include:
+                payload["documents"].append([entry["document"] for _, _, entry in top])
+            if "metadatas" in include:
+                payload["metadatas"].append([dict(entry["metadata"]) for _, _, entry in top])
+            if "distances" in include:
+                payload["distances"].append([distance for distance, _, _ in top])
+
         return payload
 
     def delete(self, *, ids: Iterable[str]) -> None:
@@ -112,3 +157,23 @@ class Collection:
                 "embedding": list(content.get("embedding") or []),
             }
         self._entries = restored
+
+    @staticmethod
+    def _cosine_similarity(vec_a: Iterable[float], vec_b: Iterable[float]) -> float:
+        a = list(vec_a)
+        b = list(vec_b)
+        if len(a) != len(b) or not a:
+            return 0.0
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+        if not norm_a or not norm_b:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    @staticmethod
+    def _matches_where(metadata: Dict[str, Any], where: Dict[str, Any]) -> bool:
+        for key, value in where.items():
+            if metadata.get(key) != value:
+                return False
+        return True

--- a/tests/core/test_vector_memory.py
+++ b/tests/core/test_vector_memory.py
@@ -1,4 +1,5 @@
 import importlib
+import types
 from pathlib import Path
 
 import pytest
@@ -100,3 +101,67 @@ def test_vector_memory_documentation_fallback(tmp_path, monkeypatch):
 
     assert results, "expected documentation fallback to produce a match"
     assert results[0].metadata.get("category") == "documentation"
+
+
+def test_vector_memory_retrieve_scoped_queries(tmp_path, monkeypatch):
+    modules = _prepare(tmp_path, monkeypatch)
+    vector_memory = modules["utils.vector_memory"]
+
+    store = vector_memory.VectorMemoryStore("Assistant")
+
+    monkeypatch.setattr(store, "count", lambda: 5)
+
+    calls = []
+
+    def fake_query(self, *, query_embeddings, n_results, include, where=None):
+        calls.append({"n_results": n_results, "include": list(include), "where": where})
+        if where is None:
+            return {
+                "documents": [[
+                    "Launch the assistant from the management window.",
+                    "Documentation filler entry.",
+                ]],
+                "metadatas": [[
+                    {
+                        "category": "documentation",
+                        "sequence": 1,
+                        "created_at": "2024-01-01T00:00:00Z",
+                    },
+                    {
+                        "category": "documentation",
+                        "sequence": 2,
+                        "created_at": "2024-01-01T00:00:01Z",
+                    },
+                ]],
+                "distances": [[0.1, 0.95]],
+            }
+        if where == {"category": "chat_history"}:
+            return {
+                "documents": [["Remember to check yesterday's notes."]],
+                "metadatas": [[
+                    {
+                        "category": "chat_history",
+                        "sequence": 3,
+                        "created_at": "2024-01-01T00:00:02Z",
+                    }
+                ]],
+                "distances": [[0.8]],
+            }
+        return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+    monkeypatch.setattr(store.collection, "query", types.MethodType(fake_query, store.collection))
+
+    results = store.retrieve(
+        "assistant launch help",
+        top_k=2,
+        threshold=0.9,
+        category_thresholds={"documentation": 0.2, "chat_history": 0.7},
+        fallback_categories={"documentation": 1, "chat_history": 1},
+    )
+
+    assert results
+    assert [item.metadata.get("category") for item in results] == ["documentation", "chat_history"]
+
+    assert calls[0]["n_results"] == 4
+    assert "embeddings" not in calls[0]["include"]
+    assert any(call["where"] == {"category": "chat_history"} for call in calls)

--- a/utils/vector_memory.py
+++ b/utils/vector_memory.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import math
 import threading
+from collections.abc import Iterable as IterableABC
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional
@@ -217,31 +218,104 @@ class VectorMemoryStore:
             for key, value in (fallback_categories or {}).items()
         }
 
+        threshold = float(threshold)
         query_vector = self.embedding_function([query_text])[0]
-        payload = self.collection.get(include=["documents", "metadatas", "embeddings"])
-        documents = payload.get("documents") or []
-        metadatas = payload.get("metadatas") or []
-        embeddings = payload.get("embeddings") or []
+
+        effective_top_k = max(0, int(top_k))
+        fallback_total = sum(fallback_limits.values()) if fallback_limits else 0
+        initial_limit = effective_top_k + fallback_total
+        if initial_limit <= 0:
+            return []
+
+        include_fields = ["documents", "metadatas", "distances"]
+
+        def similarity_from_distance(distance: Any) -> float:
+            try:
+                value = 1.0 - float(distance)
+            except Exception:
+                return 0.0
+            return max(min(value, 1.0), -1.0)
+
+        def make_key(metadata: Dict[str, Any], document: str) -> Any:
+            sequence = metadata.get("sequence") if isinstance(metadata, dict) else None
+            created = metadata.get("created_at") if isinstance(metadata, dict) else None
+            category = metadata.get("category") if isinstance(metadata, dict) else None
+            doc_hash = metadata.get("doc_hash") if isinstance(metadata, dict) else None
+            return (sequence, created, category, doc_hash, document)
 
         results: List[RetrievedMemory] = []
         fallback_pool: Dict[str, List[RetrievedMemory]] = {key: [] for key in fallback_limits}
+        seen_keys: set = set()
 
-        for doc, metadata, embedding in zip(documents, metadatas, embeddings):
-            if not isinstance(doc, str) or not isinstance(metadata, dict):
-                continue
-            similarity = _cosine_similarity(query_vector, embedding)
-            category = str(metadata.get("category", "")) if metadata else ""
-            category_threshold = category_thresholds.get(category, threshold)
-            if similarity >= category_threshold:
-                results.append(RetrievedMemory(doc, metadata, similarity))
-                continue
-            if category in fallback_pool:
-                fallback_pool[category].append(RetrievedMemory(doc, metadata, similarity))
+        def ingest_payload(payload: Dict[str, Any]) -> None:
+            if not payload:
+                return
+            docs_list = payload.get("documents") or []
+            metas_list = payload.get("metadatas") or []
+            dist_list = payload.get("distances") or []
+            if not docs_list or not metas_list:
+                return
+            # Chroma responses return lists per query; we only issue single queries.
+            documents_inner = docs_list[0] if isinstance(docs_list[0], list) else docs_list
+            metadatas_inner = metas_list[0] if isinstance(metas_list[0], list) else metas_list
+            distances_inner_raw = dist_list[0] if dist_list and isinstance(dist_list[0], list) else dist_list
+            distances_inner = list(distances_inner_raw) if isinstance(distances_inner_raw, IterableABC) else []
+            if len(distances_inner) < len(documents_inner):
+                distances_inner.extend([0.0] * (len(documents_inner) - len(distances_inner)))
+
+            for doc, metadata, distance in zip(documents_inner, metadatas_inner, distances_inner):
+                if not isinstance(doc, str) or not isinstance(metadata, dict):
+                    continue
+                key = make_key(metadata, doc)
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                similarity = similarity_from_distance(distance)
+                category = str(metadata.get("category", "")) if metadata else ""
+                category_threshold = category_thresholds.get(category, threshold)
+                memory = RetrievedMemory(doc, metadata, similarity)
+                if similarity >= category_threshold:
+                    results.append(memory)
+                elif category in fallback_limits:
+                    fallback_pool.setdefault(category, []).append(memory)
+
+        payload = self.collection.query(
+            query_embeddings=[query_vector],
+            n_results=initial_limit,
+            include=include_fields,
+        )
+        ingest_payload(payload)
+
+        if fallback_limits:
+            for category, limit in fallback_limits.items():
+                if limit <= 0:
+                    continue
+                while True:
+                    category_results = [
+                        item for item in results if str(item.metadata.get("category", "")) == category
+                    ]
+                    pool = fallback_pool.get(category, [])
+                    needed = limit - len(category_results)
+                    if needed <= 0 or len(pool) >= needed:
+                        break
+                    additional_needed = needed - len(pool)
+                    if additional_needed <= 0:
+                        break
+                    extra_payload = self.collection.query(
+                        query_embeddings=[query_vector],
+                        n_results=additional_needed,
+                        include=include_fields,
+                        where={"category": category},
+                    )
+                    before = len(fallback_pool.get(category, []))
+                    ingest_payload(extra_payload)
+                    after = len(fallback_pool.get(category, []))
+                    if after <= before:
+                        break
 
         if fallback_pool:
             for category, pool in fallback_pool.items():
                 pool.sort(key=lambda item: item.similarity, reverse=True)
-                fallback_pool[category] = pool
 
         # Sort primary matches by similarity before enforcing fallbacks.
         results.sort(key=lambda item: item.similarity, reverse=True)


### PR DESCRIPTION
## Summary
- refactor `VectorMemoryStore.retrieve` to issue scoped `collection.query` calls, reusing distances and targeted category fallbacks without loading full embeddings
- extend the lightweight Chroma `Collection` shim with a cosine-based `query` implementation that honors metadata filters
- add a regression test that verifies retrieval limits database calls to the requested scope while maintaining fallback quotas

## Testing
- python -m compileall .
- python -m pytest -m core_headless


------
https://chatgpt.com/codex/tasks/task_e_68deaf3d1838832a96057799f7a824b1