### PR TITLE
Support runtime custom transcript variant map

### DIFF
--- a/background_agents/__init__.py
+++ b/background_agents/__init__.py
@@ -3,6 +3,15 @@
 from .datetime_memory_agent import refresh_datetime_memory
 from .document_memory_agent import refresh_document_memory
 from .manage_think import ManageThinkAgent, ManageThinkResult, load_manage_think_agent
+from .transcript_cleanup_agent import (
+    BackgroundAgentResources as TranscriptCleanupResources,
+    TranscriptCleanupAgent,
+    TranscriptCleanupResult,
+    TranscriptCorrection,
+    load_background_agent_resources as load_transcript_cleanup_resources,
+    load_transcript_cleanup_agent,
+    normalize_transcript,
+)
 from .tts_preprocessing_agent.background_agent import (
     BackgroundAgentResources,
     TTSPreprocessingAgent,
@@ -22,4 +31,11 @@ __all__ = [
     "ManageThinkAgent",
     "ManageThinkResult",
     "load_manage_think_agent",
+    "TranscriptCleanupAgent",
+    "TranscriptCleanupResult",
+    "TranscriptCorrection",
+    "load_transcript_cleanup_agent",
+    "load_transcript_cleanup_resources",
+    "normalize_transcript",
+    "TranscriptCleanupResources",
 ]

--- a/background_agents/transcript_cleanup_agent/__init__.py
+++ b/background_agents/transcript_cleanup_agent/__init__.py
@@ -1,0 +1,21 @@
+"""Transcript cleanup background agent package."""
+
+from .background_agent import (
+    BackgroundAgentResources,
+    TranscriptCleanupAgent,
+    TranscriptCleanupResult,
+    TranscriptCorrection,
+    load_background_agent_resources,
+    load_transcript_cleanup_agent,
+    normalize_transcript,
+)
+
+__all__ = [
+    "BackgroundAgentResources",
+    "TranscriptCleanupAgent",
+    "TranscriptCleanupResult",
+    "TranscriptCorrection",
+    "load_background_agent_resources",
+    "load_transcript_cleanup_agent",
+    "normalize_transcript",
+]

--- a/background_agents/transcript_cleanup_agent/background_agent.py
+++ b/background_agents/transcript_cleanup_agent/background_agent.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import json
+import threading
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from pathlib import Path
+import re
+from typing import Iterable, Optional, Sequence
+
+from utils.config_paths import get_data_dir, get_logs_dir, get_logger
+from utils.io_atomic import atomic_append_lines
+
+_DEFAULT_AGENT_DIR = Path(__file__).resolve().parent
+
+logger = get_logger(__name__)
+
+_WORD_PATTERN = re.compile(r"[A-Za-z]+(?:'[A-Za-z]+)?")
+_BOUNDARY_TEMPLATE = r"(?<![A-Za-z0-9]){token}(?![A-Za-z0-9])"
+
+
+@dataclass(frozen=True)
+class BackgroundAgentResources:
+    """Static resources and configuration for the transcript cleanup agent."""
+
+    base_path: Path
+    config: dict
+    base_variant_map: dict[str, tuple[str, ...]]
+    supplemental_phrases: tuple[str, ...]
+    phrase_thresholds: dict[str, float]
+    default_threshold: float
+    log_path: Path
+    max_log_bytes: int
+    log_keep: int
+    custom_variant_map_path: Path
+
+
+@dataclass(frozen=True)
+class TranscriptCorrection:
+    """A single correction applied to the transcript."""
+
+    original: str
+    replacement: str
+    reason: str
+    score: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class TranscriptCleanupResult:
+    """Result payload returned after normalization."""
+
+    text: str
+    corrections: tuple[TranscriptCorrection, ...]
+
+
+class TranscriptCleanupAgent:
+    """Normalizes Whisper transcripts prior to keyword routing."""
+
+    def __init__(self, resources: BackgroundAgentResources) -> None:
+        self._resources = resources
+        self._lock = threading.RLock()
+        self._base_variant_map = dict(resources.base_variant_map)
+        self._custom_variant_map: dict[str, tuple[str, ...]] = {}
+        self._custom_variant_map_path = resources.custom_variant_map_path
+        self._custom_variant_mtime: Optional[int] = None
+        self._custom_variant_size: Optional[int] = None
+
+        self._variant_patterns: list[tuple[re.Pattern[str], str, str]] = []
+        self._supplemental_phrases = tuple(resources.supplemental_phrases)
+        self._static_tracked_phrases: set[str] = {
+            phrase.strip() for phrase in self._supplemental_phrases if phrase.strip()
+        }
+        self._static_tracked_phrases.update(_collect_keyword_phrases())
+        self._tracked_phrases: set[str] = set(self._static_tracked_phrases)
+
+        self._phrase_thresholds = dict(resources.phrase_thresholds)
+        self._default_threshold = max(0.0, min(1.0, resources.default_threshold))
+
+        self._rebuild_variant_state()
+        self._refresh_custom_variants_if_needed(force=True)
+
+    @property
+    def tracked_phrases(self) -> tuple[str, ...]:
+        with self._lock:
+            self._refresh_custom_variants_if_needed()
+            return tuple(sorted({phrase for phrase in self._tracked_phrases if phrase}))
+
+    def normalize(self, text: str) -> TranscriptCleanupResult:
+        with self._lock:
+            return self._normalize_locked(text)
+
+    def _normalize_locked(self, text: str) -> TranscriptCleanupResult:
+        self._refresh_custom_variants_if_needed()
+
+        if not text:
+            return TranscriptCleanupResult(text=text, corrections=())
+
+        working = text
+        corrections: list[TranscriptCorrection] = []
+
+        for pattern, canonical, reason in self._variant_patterns:
+            def _replacer(match: re.Match[str]) -> str:
+                original = match.group(0)
+                if original.lower() == canonical.lower():
+                    return original
+                replacement = _preserve_case(canonical, original)
+                corrections.append(
+                    TranscriptCorrection(
+                        original=original,
+                        replacement=replacement,
+                        reason=reason,
+                    )
+                )
+                return replacement
+
+            working = pattern.sub(_replacer, working)
+
+        fuzzy_replacements = self._detect_fuzzy_replacements(working)
+        if fuzzy_replacements:
+            working, fuzzy_corrections = _apply_replacements(working, fuzzy_replacements)
+            corrections.extend(fuzzy_corrections)
+
+        result = TranscriptCleanupResult(text=working, corrections=tuple(corrections))
+
+        if corrections:
+            self._log_corrections(text, result)
+
+        return result
+
+    def _detect_fuzzy_replacements(self, text: str) -> list[tuple[int, int, str, TranscriptCorrection]]:
+        tokens = list(_WORD_PATTERN.finditer(text))
+        if not tokens:
+            return []
+
+        replacements: list[tuple[int, int, str, TranscriptCorrection]] = []
+        for phrase in self._tracked_phrases:
+            canonical = phrase.strip()
+            if not canonical:
+                continue
+            canonical_lower = canonical.lower()
+            word_count = len(canonical_lower.split())
+            if word_count == 0 or word_count > len(tokens):
+                continue
+            threshold = self._phrase_thresholds.get(canonical_lower, self._default_threshold)
+            for index in range(len(tokens) - word_count + 1):
+                start = tokens[index].start()
+                end = tokens[index + word_count - 1].end()
+                candidate = text[start:end]
+                candidate_lower = candidate.lower()
+                if candidate_lower == canonical_lower:
+                    continue
+                score = SequenceMatcher(None, candidate_lower, canonical_lower).ratio()
+                if score >= threshold:
+                    replacement = _preserve_case(canonical, candidate)
+                    correction = TranscriptCorrection(
+                        original=candidate,
+                        replacement=replacement,
+                        reason=f"fuzzy:{canonical_lower}",
+                        score=round(score, 4),
+                    )
+                    replacements.append((start, end, replacement, correction))
+        return replacements
+
+    def _refresh_custom_variants_if_needed(self, *, force: bool = False) -> None:
+        path = self._custom_variant_map_path
+
+        try:
+            stat_result = path.stat()
+        except FileNotFoundError:
+            if force or self._custom_variant_map:
+                self._custom_variant_map = {}
+                self._custom_variant_mtime = None
+                self._custom_variant_size = None
+                self._rebuild_variant_state()
+            return
+        except Exception:
+            logger.exception("Failed to stat custom transcript variant map at %s", path)
+            return
+
+        mtime = stat_result.st_mtime_ns
+        size = stat_result.st_size
+        if not force and self._custom_variant_mtime == mtime and self._custom_variant_size == size:
+            return
+
+        updated_map = _load_variant_map(path)
+        if updated_map != self._custom_variant_map:
+            self._custom_variant_map = updated_map
+            self._rebuild_variant_state()
+
+        self._custom_variant_mtime = mtime
+        self._custom_variant_size = size
+
+    def _rebuild_variant_state(self) -> None:
+        combined = _merge_variant_maps(self._base_variant_map, self._custom_variant_map)
+
+        patterns: list[tuple[re.Pattern[str], str, str]] = []
+        for canonical, variants in combined.items():
+            normalized_canonical = canonical.strip()
+            if not normalized_canonical:
+                continue
+            for variant in variants:
+                normalized_variant = variant.strip()
+                if not normalized_variant:
+                    continue
+                pattern = re.compile(
+                    _BOUNDARY_TEMPLATE.format(token=re.escape(normalized_variant)),
+                    re.IGNORECASE,
+                )
+                reason = f"variant:{normalized_canonical.lower()}"
+                patterns.append((pattern, normalized_canonical, reason))
+
+        self._variant_patterns = patterns
+
+        tracked = set(self._static_tracked_phrases)
+        tracked.update(canonical for canonical in combined.keys() if canonical)
+        self._tracked_phrases = tracked
+
+    def _log_corrections(self, original: str, result: TranscriptCleanupResult) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        lines = [
+            f"{timestamp} original={original!r}",
+        ]
+        for correction in result.corrections:
+            if correction.score is not None:
+                lines.append(
+                    f"    {correction.reason} score={correction.score}"
+                    f" {correction.original!r} -> {correction.replacement!r}"
+                )
+            else:
+                lines.append(
+                    f"    {correction.reason} {correction.original!r}"
+                    f" -> {correction.replacement!r}"
+                )
+        lines.append(f"    normalized={result.text!r}")
+        try:
+            atomic_append_lines(
+                self._resources.log_path,
+                lines,
+                max_bytes=self._resources.max_log_bytes,
+                keep=self._resources.log_keep,
+            )
+        except Exception:
+            logger.exception("Failed to append transcript cleanup audit log")
+
+
+def _apply_replacements(
+    text: str,
+    replacements: Sequence[tuple[int, int, str, TranscriptCorrection]],
+) -> tuple[str, list[TranscriptCorrection]]:
+    if not replacements:
+        return text, []
+
+    sorted_replacements = sorted(replacements, key=lambda item: (item[0], -(item[1] - item[0])))
+    filtered: list[tuple[int, int, str, TranscriptCorrection]] = []
+    last_end = -1
+    for start, end, replacement, correction in sorted_replacements:
+        if start < last_end:
+            continue
+        filtered.append((start, end, replacement, correction))
+        last_end = end
+
+    if not filtered:
+        return text, []
+
+    segments: list[str] = []
+    cursor = 0
+    applied: list[TranscriptCorrection] = []
+    for start, end, replacement, correction in filtered:
+        segments.append(text[cursor:start])
+        segments.append(replacement)
+        cursor = end
+        applied.append(correction)
+    segments.append(text[cursor:])
+
+    return "".join(segments), applied
+
+
+def _merge_variant_maps(
+    base: dict[str, tuple[str, ...]],
+    custom: dict[str, tuple[str, ...]],
+) -> dict[str, tuple[str, ...]]:
+    combined: dict[str, list[str]] = {}
+
+    for source in (base, custom):
+        for canonical, variants in source.items():
+            canonical_clean = canonical.strip()
+            if not canonical_clean:
+                continue
+            bucket = combined.setdefault(canonical_clean, [])
+            for variant in variants:
+                normalized_variant = variant.strip()
+                if normalized_variant and normalized_variant not in bucket:
+                    bucket.append(normalized_variant)
+
+    return {canonical: tuple(variants) for canonical, variants in combined.items() if variants}
+
+
+def _preserve_case(canonical: str, sample: str) -> str:
+    if sample.isupper():
+        return canonical.upper()
+    if sample.islower():
+        return canonical.lower()
+    if sample[:1].isupper() and sample[1:].islower():
+        if not canonical:
+            return canonical
+        return canonical[:1].upper() + canonical[1:]
+    tokens = sample.split()
+    if tokens and all(token[:1].isupper() and token[1:].islower() for token in tokens):
+        return " ".join(part.capitalize() for part in canonical.split())
+    return canonical
+
+
+def _collect_keyword_phrases() -> set[str]:
+    phrases: set[str] = set()
+    try:
+        from tools import keywords
+
+        for keyword in keywords.ALL_KEYWORDS:
+            for target in keyword.fuzzy_targets:
+                cleaned = target.strip()
+                if cleaned:
+                    phrases.add(cleaned)
+    except Exception:
+        logger.exception("Failed to collect keyword phrases for transcript cleanup")
+    return phrases
+
+
+def load_background_agent_resources(
+    base_path: Optional[Path] = None,
+) -> Optional[BackgroundAgentResources]:
+    agent_path = Path(base_path) if base_path else _DEFAULT_AGENT_DIR
+    agent_path = agent_path.expanduser()
+    try:
+        agent_path = agent_path.resolve()
+    except FileNotFoundError:
+        logger.exception("Transcript cleanup agent directory %s not found", agent_path)
+        return None
+
+    identity_path = agent_path / "identity.json"
+    if not identity_path.exists():
+        logger.warning("Transcript cleanup agent identity missing at %s", identity_path)
+        return None
+
+    try:
+        config = json.loads(identity_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.exception("Failed to parse transcript cleanup identity from %s", identity_path)
+        return None
+
+    variant_path = _resolve_agent_path(agent_path, config.get("variant_map"))
+    variant_map = _load_variant_map(variant_path)
+
+    supplemental_path = _resolve_agent_path(agent_path, config.get("supplemental_phrases"))
+    supplemental_phrases = _load_supplemental_phrases(supplemental_path)
+
+    raw_thresholds = config.get("phrase_thresholds", {})
+    phrase_thresholds: dict[str, float] = {}
+    if isinstance(raw_thresholds, dict):
+        for key, value in raw_thresholds.items():
+            if not isinstance(key, str):
+                continue
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                continue
+            numeric = max(0.0, min(1.0, numeric))
+            phrase_thresholds[key.strip().lower()] = numeric
+
+    default_threshold = config.get("default_threshold", 0.84)
+    try:
+        default_threshold = float(default_threshold)
+    except (TypeError, ValueError):
+        default_threshold = 0.84
+
+    log_file = str(config.get("log_file") or "transcript_cleanup.log").strip() or "transcript_cleanup.log"
+    log_path = get_logs_dir() / log_file
+
+    max_log_bytes = config.get("max_log_bytes", 262144)
+    try:
+        max_log_bytes = int(max_log_bytes)
+    except (TypeError, ValueError):
+        max_log_bytes = 262144
+
+    log_keep = config.get("log_keep", 5)
+    try:
+        log_keep = int(log_keep)
+    except (TypeError, ValueError):
+        log_keep = 5
+
+    return BackgroundAgentResources(
+        base_path=agent_path,
+        config=config,
+        base_variant_map=variant_map,
+        supplemental_phrases=supplemental_phrases,
+        phrase_thresholds=phrase_thresholds,
+        default_threshold=default_threshold,
+        log_path=log_path,
+        max_log_bytes=max_log_bytes,
+        log_keep=log_keep,
+        custom_variant_map_path=_ensure_custom_variant_map_path(),
+    )
+
+
+def _resolve_agent_path(base: Path, value: Optional[str]) -> Path:
+    if value:
+        candidate = Path(value)
+    else:
+        candidate = Path()
+    if not candidate.is_absolute():
+        candidate = (base / candidate).expanduser()
+    return candidate
+
+
+def _ensure_custom_variant_map_path() -> Path:
+    base_dir = get_data_dir() / "langgraph_agents" / "transcript_cleanup_agent"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    path = base_dir / "custom_variant_map.json"
+    if not path.exists():
+        try:
+            path.write_text("{}\n", encoding="utf-8")
+        except Exception:
+            logger.exception("Failed to initialize custom transcript variant map at %s", path)
+    return path
+
+
+def _load_variant_map(path: Path) -> dict[str, tuple[str, ...]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.warning("Transcript cleanup variant map missing at %s", path)
+        return {}
+    except Exception:
+        logger.exception("Failed to parse transcript cleanup variant map at %s", path)
+        return {}
+
+    variants: dict[str, tuple[str, ...]] = {}
+    if isinstance(payload, dict):
+        for canonical, values in payload.items():
+            if not isinstance(canonical, str):
+                continue
+            items: list[str] = []
+            if isinstance(values, str):
+                items.append(values)
+            elif isinstance(values, Iterable):
+                for entry in values:
+                    if isinstance(entry, str):
+                        trimmed = entry.strip()
+                        if trimmed:
+                            items.append(trimmed)
+            canonical_clean = canonical.strip()
+            if canonical_clean and items:
+                variants[canonical_clean] = tuple(dict.fromkeys(items))
+    return variants
+
+
+def _load_supplemental_phrases(path: Path) -> tuple[str, ...]:
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ()
+    except Exception:
+        logger.exception("Failed to read supplemental transcript phrases from %s", path)
+        return ()
+    phrases = [line.strip() for line in contents.splitlines() if line.strip()]
+    return tuple(dict.fromkeys(phrases))
+
+
+def load_transcript_cleanup_agent(
+    base_path: Optional[Path] = None,
+    *,
+    resources: Optional[BackgroundAgentResources] = None,
+) -> Optional[TranscriptCleanupAgent]:
+    resource_bundle = resources or load_background_agent_resources(base_path)
+    if resource_bundle is None:
+        return None
+    return TranscriptCleanupAgent(resource_bundle)
+
+
+_cached_agent_lock = threading.Lock()
+_cached_agent: Optional[TranscriptCleanupAgent] = None
+
+
+def _get_cached_agent() -> Optional[TranscriptCleanupAgent]:
+    global _cached_agent
+    if _cached_agent is not None:
+        return _cached_agent
+    with _cached_agent_lock:
+        if _cached_agent is None:
+            try:
+                _cached_agent = load_transcript_cleanup_agent()
+            except Exception:
+                logger.exception("Failed to initialize transcript cleanup agent")
+                _cached_agent = None
+    return _cached_agent
+
+
+def normalize_transcript(text: str) -> TranscriptCleanupResult:
+    agent = _get_cached_agent()
+    if agent is None:
+        return TranscriptCleanupResult(text=text, corrections=())
+    return agent.normalize(text)
+
+
+__all__ = [
+    "BackgroundAgentResources",
+    "TranscriptCleanupAgent",
+    "TranscriptCleanupResult",
+    "TranscriptCorrection",
+    "load_background_agent_resources",
+    "load_transcript_cleanup_agent",
+    "normalize_transcript",
+]

--- a/background_agents/transcript_cleanup_agent/identity.json
+++ b/background_agents/transcript_cleanup_agent/identity.json
@@ -1,0 +1,15 @@
+{
+  "description": "Normalizes Whisper transcripts before keyword routing.",
+  "variant_map": "variant_map.json",
+  "supplemental_phrases": "supplemental_phrases.txt",
+  "default_threshold": 0.84,
+  "phrase_thresholds": {
+    "look at my clipboard": 0.88,
+    "chat with assistant": 0.86,
+    "chat with default": 0.86,
+    "goodbye assistant": 0.86
+  },
+  "log_file": "transcript_cleanup.log",
+  "max_log_bytes": 262144,
+  "log_keep": 5
+}

--- a/background_agents/transcript_cleanup_agent/supplemental_phrases.txt
+++ b/background_agents/transcript_cleanup_agent/supplemental_phrases.txt
@@ -1,0 +1,7 @@
+look at my clipboard
+look at my screen
+chat with assistant
+chat with default
+chat with einstein
+goodbye assistant
+goodbye default

--- a/background_agents/transcript_cleanup_agent/variant_map.json
+++ b/background_agents/transcript_cleanup_agent/variant_map.json
@@ -1,0 +1,26 @@
+{
+  "clipboard": [
+    "clubboard",
+    "clip board",
+    "clipbord",
+    "clipbaord",
+    "clibboard"
+  ],
+  "look at my clipboard": [
+    "look at my clubboard",
+    "look at my club board",
+    "look at my clip board"
+  ],
+  "chat with default": [
+    "chat with defunct",
+    "chat with defaultt"
+  ],
+  "chat with assistant": [
+    "chat with assissant",
+    "chat with assistent"
+  ],
+  "goodbye assistant": [
+    "good bye assistant",
+    "good bye, assistant"
+  ]
+}

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -119,6 +119,37 @@ The `<identity>` placeholder uses the directory names under `third_party/social_
 
 The same registry now powers the push-to-talk workflow: when the user holds the right Ctrl hotkey, CtrlSpeak transcribes the utterance and checks it against these keywords before typing anything. Phrases like “chat with assistant” launch the corresponding bot immediately, “chat with default” first stops any existing session before starting the default identity, and “goodbye <identity>” routes through the same shutdown helper used by the tray menu. Because the text insertion path never runs for handled keywords, make sure any new phrases you add here have matching automation hooks so the hotkey and transcription server remain in sync with voice-triggered behaviour.
 
+## Transcript cleanup background agent (`background_agents/transcript_cleanup_agent/`)
+
+CtrlSpeak normalises Whisper transcripts before keyword routing via the transcript cleanup background agent. The helper applies a configurable set of substitutions so the hotkey workflow, transcription server, and SocialRobot UI all see canonical phrases even when the speech-to-text model mishears them (for example, “clubboard” instead of “clipboard” or “chat with defunct” instead of “chat with default”).
+
+### Public API
+
+| Function | Purpose |
+| --- | --- |
+| `normalize_transcript(text: str) -> TranscriptCleanupResult` | Normalises the supplied transcript, returning the cleaned string and a tuple of `TranscriptCorrection` records describing each change. When the agent resources are unavailable the original text is returned unchanged. |
+| `load_transcript_cleanup_agent(...) -> TranscriptCleanupAgent` | Loads the agent using the on-disk configuration bundle. Most callers should rely on `normalize_transcript` so resources are cached automatically. |
+
+### Configuration bundle
+
+- `identity.json` defines the correction thresholds, audit-log parameters, and pointers to the other resource files.
+- `variant_map.json` lists canonical phrases mapped to their known misrecognitions. Add entries here when Whisper returns a consistent misspelling; the keys are treated as the desired replacement text.
+- `supplemental_phrases.txt` seeds the fuzzy matcher with project terminology (for example, documented clipboard and chat commands) so similar phrases are normalised even without an explicit variant entry.
+- `${data_root}/langgraph_agents/transcript_cleanup_agent/custom_variant_map.json` is a user-editable overlay that lives outside the packaged application. Operators can add or modify entries at runtime (even while CtrlSpeak is running) without touching the read-only resources bundled with the executable. The agent re-reads this file before each cleanup pass, merging the custom entries with the baked-in `variant_map.json` so new corrections apply immediately.
+
+The loader merges these resources with the authoritative keyword list exposed by `tools.keywords`. During normalisation the agent first applies the explicit variants, then performs a fuzzy sweep over every tracked phrase using the thresholds in `identity.json`. All corrections are recorded in `${logs_root}/transcript_cleanup.log`, capped at 256 KiB with rotation so operators can audit what changed.
+
+### Integration points
+
+- `utils.system.handle_transcribed_text_from_hotkey` cleans transcripts before testing any keywords so push-to-talk users get the corrected behaviour immediately.
+- `utils.system.handle_transcription_keyword` returns the cleaned text to HTTP clients when no keyword is triggered, ensuring downstream services receive the canonical phrases.
+- `third_party.social_robot.main._handle_user_request` normalises every utterance before it reaches SocialRobot, printing the adjusted phrase in the console when a correction occurs so operators can see what changed.
+
+### Testing
+
+- Unit tests live in `tests/core/test_transcript_cleanup_agent.py`.
+- Keyword routing tests under `tests/core/test_system_hotkey_keywords.py` and `tests/core/test_system_transcription_keywords.py` cover common misrecognitions (such as “chat with defunct”) to ensure the hotkey and transcription paths keep working as new variants are added.
+
 ### Testing guidance
 
 - Unit tests live in `tests/core/test_tools_keywords.py` and validate phrase detection along with payload lookups.

--- a/tests/core/test_system_hotkey_keywords.py
+++ b/tests/core/test_system_hotkey_keywords.py
@@ -160,6 +160,23 @@ def test_hotkey_supports_fuzzy_chat(bot_module):
     assert start_calls == ["assistant"]
 
 
+def test_hotkey_normalizes_defunct_identity(bot_module):
+    start_calls: list[str] = []
+
+    bot_module.get_active_identity = lambda: None
+
+    def _start_bot(*, identity: str | None = None, **_kwargs) -> bool:
+        start_calls.append(identity)
+        return True
+
+    bot_module.start_bot = _start_bot
+
+    handled = system.handle_transcribed_text_from_hotkey("chat with defunct")
+
+    assert handled is True
+    assert start_calls == ["default"]
+
+
 def test_hotkey_update_documentation_uses_active_identity(monkeypatch, bot_module):
     calls: list[tuple[str, bool, str | None]] = []
 

--- a/tests/core/test_system_transcription_keywords.py
+++ b/tests/core/test_system_transcription_keywords.py
@@ -166,6 +166,24 @@ def test_handle_transcription_keyword_supports_fuzzy_chat(bot_module):
     assert start_calls == ["assistant"]
 
 
+def test_handle_transcription_keyword_normalizes_defunct(bot_module):
+    bot_module.get_active_identity = lambda: None
+
+    start_calls: list[str | None] = []
+
+    def _start_bot(*, identity: str | None = None, **_kwargs):
+        start_calls.append(identity)
+        return True
+
+    bot_module.start_bot = _start_bot
+
+    handled, text = system.handle_transcription_keyword("chat with defunct")
+
+    assert handled is True
+    assert text == ""
+    assert start_calls == ["default"]
+
+
 def test_handle_transcription_keyword_ignores_start_for_active_identity(bot_module):
     bot_module.get_active_identity = lambda: "assistant"
 
@@ -198,3 +216,10 @@ def test_handle_transcription_keyword_ignores_when_no_bot_active(bot_module):
 
     assert handled is False
     assert text == "goodbye assistant"
+
+
+def test_handle_transcription_keyword_returns_normalized_text():
+    handled, text = system.handle_transcription_keyword("please look at my clubboard")
+
+    assert handled is False
+    assert text == "please look at my clipboard"

--- a/tests/core/test_transcript_cleanup_agent.py
+++ b/tests/core/test_transcript_cleanup_agent.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+
+def _raise_requests_error(*_args, **_kwargs):
+    raise RuntimeError("requests is not installed in the test environment")
+
+
+sys.modules.setdefault(
+    "requests",
+    types.SimpleNamespace(get=_raise_requests_error, post=_raise_requests_error),
+)
+
+from background_agents.transcript_cleanup_agent import (  # noqa: E402
+    load_transcript_cleanup_agent,
+    normalize_transcript,
+)
+from background_agents.transcript_cleanup_agent import background_agent as cleanup_module  # noqa: E402
+
+pytestmark = pytest.mark.core_headless
+
+
+def test_transcript_cleanup_agent_rewrites_common_variant():
+    agent = load_transcript_cleanup_agent()
+    assert agent is not None
+
+    result = agent.normalize("Please look at my clubboard right now.")
+
+    assert result.text == "Please look at my clipboard right now."
+    assert result.corrections
+    assert any(correction.reason.startswith("variant:") for correction in result.corrections)
+
+
+def test_normalize_transcript_corrects_chat_with_defunct():
+    result = normalize_transcript("could you chat with defunct this instant")
+
+    assert result.text == "could you chat with default this instant"
+    assert any(
+        correction.reason.startswith("variant:") or correction.reason.startswith("fuzzy:")
+        for correction in result.corrections
+    )
+
+
+def _load_agent_with_custom_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(cleanup_module, "_cached_agent", None)
+    monkeypatch.setattr(cleanup_module, "get_data_dir", lambda: tmp_path)
+    return cleanup_module.load_transcript_cleanup_agent()
+
+
+def test_custom_variant_map_extends_rewrites(tmp_path, monkeypatch):
+    agent = _load_agent_with_custom_root(tmp_path, monkeypatch)
+
+    custom_path = tmp_path / "langgraph_agents" / "transcript_cleanup_agent" / "custom_variant_map.json"
+    payload = {"launch autopilot": ["launch auto pilot"]}
+    custom_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = agent.normalize("please launch auto pilot now")
+
+    assert result.text == "please launch autopilot now"
+    assert any(correction.replacement.lower() == "launch autopilot" for correction in result.corrections)
+
+
+def test_custom_variant_map_refreshes_on_change(tmp_path, monkeypatch):
+    agent = _load_agent_with_custom_root(tmp_path, monkeypatch)
+
+    custom_path = tmp_path / "langgraph_agents" / "transcript_cleanup_agent" / "custom_variant_map.json"
+    custom_path.write_text(json.dumps({}, indent=2), encoding="utf-8")
+
+    # First write introduces an entry.
+    custom_path.write_text(
+        json.dumps({"launch autopilot": ["launch auto pilot"]}),
+        encoding="utf-8",
+    )
+    agent.normalize("please launch auto pilot")
+
+    # Second write changes the payload to include a new mapping.
+    custom_path.write_text(
+        json.dumps(
+            {
+                "launch autopilot": ["launch auto pilot"],
+                "open autopilot": ["open auto pilot"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = agent.normalize("could you open auto pilot")
+
+    assert result.text == "could you open autopilot"
+    assert any(
+        correction.replacement.lower() == "open autopilot" for correction in result.corrections
+    )

--- a/third_party/social_robot/main.py
+++ b/third_party/social_robot/main.py
@@ -38,6 +38,7 @@ else:
 from background_agents.datetime_memory_agent import refresh_datetime_memory
 from background_agents.document_memory_agent import refresh_document_memory
 from background_agents.manage_think import ManageThinkAgent, load_manage_think_agent
+from background_agents.transcript_cleanup_agent import normalize_transcript
 from tools import keywords, vision
 from tools.message_management import force_plaintext, requires_force_plaintext
 from utils.config_paths import get_logger
@@ -933,6 +934,23 @@ def main():
             print("-> Simulating user request:", transcript)
         else:
             print("-> User said:", transcript)
+
+        normalized = cleaned
+        try:
+            cleanup_result = normalize_transcript(cleaned)
+            normalized = cleanup_result.text.strip() or cleaned
+            if cleanup_result.corrections:
+                logger.debug(
+                    "Transcript cleanup applied for SocialRobot input: %s",
+                    cleanup_result.corrections,
+                )
+                if source != "command":
+                    print("-> Normalized transcript:", normalized)
+        except Exception:
+            logger.exception("Failed to normalize SocialRobot transcript")
+            normalized = cleaned
+
+        cleaned = normalized
 
         if tts_model.is_playing:
             tts_model.stop_playback()

--- a/utils/build_exe.py
+++ b/utils/build_exe.py
@@ -30,6 +30,7 @@ COMMON_REQUIRED_ASSETS = {
     "automation clip": assets_dir / "test.wav",
     "fun facts list": assets_dir / "fun_facts.txt",
     "TTS preprocessing agent": project_root / "background_agents" / "tts_preprocessing_agent",
+    "Transcript cleanup agent": project_root / "background_agents" / "transcript_cleanup_agent",
 }
 
 

--- a/utils/system.py
+++ b/utils/system.py
@@ -703,6 +703,21 @@ def handle_transcribed_text_from_hotkey(text: str) -> bool:
     if not cleaned:
         return False
 
+    normalized = cleaned
+    try:
+        from background_agents.transcript_cleanup_agent import normalize_transcript
+
+        cleanup_result = normalize_transcript(cleaned)
+        normalized = cleanup_result.text.strip() or cleaned
+        if cleanup_result.corrections:
+            logger.debug(
+                "Transcript cleanup applied for hotkey input: %s",
+                cleanup_result.corrections,
+            )
+    except Exception:
+        logger.exception("Failed to normalize transcript before hotkey processing")
+        normalized = cleaned
+
     try:
         from background_agents.datetime_memory_agent import refresh_datetime_memory
         from background_agents.document_memory_agent import refresh_document_memory
@@ -712,7 +727,7 @@ def handle_transcribed_text_from_hotkey(text: str) -> bool:
         logger.exception("Failed to import keyword handlers for hotkey processing")
         return False
 
-    maintenance_match = keywords.detect_memory_refresh_keyword(cleaned)
+    maintenance_match = keywords.detect_memory_refresh_keyword(normalized)
     if maintenance_match:
         target_identity = bot_integration.get_active_identity() or "assistant"
         payload = maintenance_match.keyword.payload.lower()
@@ -741,7 +756,7 @@ def handle_transcribed_text_from_hotkey(text: str) -> bool:
             )
         return True
 
-    match = keywords.detect_conversation_start_keyword(cleaned)
+    match = keywords.detect_conversation_start_keyword(normalized)
     if match:
         identity = match.keyword.payload
         active_identity = bot_integration.get_active_identity()
@@ -772,7 +787,7 @@ def handle_transcribed_text_from_hotkey(text: str) -> bool:
             logger.error("Failed to start bot '%s' from hotkey command", identity)
         return True
 
-    match = keywords.detect_conversation_end_keyword(cleaned)
+    match = keywords.detect_conversation_end_keyword(normalized)
     if match:
         identity = match.keyword.payload
         active_identity = bot_integration.get_active_identity()
@@ -941,14 +956,29 @@ def handle_transcription_keyword(text: str) -> tuple[bool, str]:
     if not cleaned:
         return False, text
 
+    normalized = cleaned
+    try:
+        from background_agents.transcript_cleanup_agent import normalize_transcript
+
+        cleanup_result = normalize_transcript(cleaned)
+        normalized = cleanup_result.text.strip() or cleaned
+        if cleanup_result.corrections:
+            logger.debug(
+                "Transcript cleanup applied for transcription keyword: %s",
+                cleanup_result.corrections,
+            )
+    except Exception:
+        logger.exception("Failed to normalize transcript in transcription server")
+        normalized = cleaned
+
     try:
         from tools import keywords
         from utils import bot_integration
     except Exception:
         logger.exception("Failed to import transcription keyword dependencies")
-        return False, text
+        return False, normalized
 
-    start_match = keywords.detect_conversation_start_keyword(cleaned)
+    start_match = keywords.detect_conversation_start_keyword(normalized)
     if start_match:
         identity = start_match.keyword.payload
         active_identity = bot_integration.get_active_identity()
@@ -1009,9 +1039,9 @@ def handle_transcription_keyword(text: str) -> tuple[bool, str]:
 
         return True, ""
 
-    match = keywords.detect_conversation_end_keyword(cleaned)
+    match = keywords.detect_conversation_end_keyword(normalized)
     if not match:
-        return False, text
+        return False, normalized
 
     identity = match.keyword.payload
     active_identity = bot_integration.get_active_identity()
@@ -1020,7 +1050,7 @@ def handle_transcription_keyword(text: str) -> tuple[bool, str]:
             "Transcription keyword '%s' ignored because no identity is active",
             identity,
         )
-        return False, text
+        return False, normalized
 
     if active_identity.lower() != identity.lower():
         logger.debug(
@@ -1028,7 +1058,7 @@ def handle_transcription_keyword(text: str) -> tuple[bool, str]:
             identity,
             active_identity,
         )
-        return False, text
+        return False, normalized
 
     logger.info("Transcription server stopping bot '%s' after goodbye keyword", identity)
 


### PR DESCRIPTION
## Summary
- allow the transcript cleanup agent to merge an AppData custom variant map with bundled resources and refresh it on each normalization
- initialize the editable variant map location under `langgraph_agents/transcript_cleanup_agent` and document the runtime workflow
- extend the transcript cleanup tests to cover custom map usage and refresh behaviour

## Testing
- python -m compileall .
- python -m pytest -m core_headless


------
https://chatgpt.com/codex/tasks/task_e_68debbbaeb70832a8fc96fb81eddc3ee