### PR TITLE
Clarify background agent orchestration in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Both flavours support Windows 10/11, enforce a single running instance, expose a
 ## Repository Layout
 
 - `main.py` – application entry point.
-- `background_agents/` – self-contained helpers that run alongside Chat with Bot. The bundled `manage_think` helper suppresses `<think>` plans for personas that set `"hide_think": true`.
+- `background_agents/` – orchestrator-managed services that run alongside Chat with Bot. These agents refresh ingested documentation, stage current date/time snapshots, filter `<think>` plans, and perform other maintenance tasks automatically whenever the LangGraph workflow requires them.
 - `assets/` – static resources such as the tray icon (`icon.ico`), the welcome video (`TrueAI_Intro_Video.mp4`), the fun-fact rotation list (`fun_facts.txt`), and the processing chime (`loading.wav`).
 - `utils/` – implementation modules (GUI, models, networking, configuration helpers, etc.).
 - `utils/build_exe.py` – helper script that runs PyInstaller with the correct data files.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -2,6 +2,8 @@
 
 This document is the authoritative index for reusable tooling that ships with CtrlSpeak. Every helper that exposes capabilities to AI agents, automation flows, or user-triggered actions must be documented here so contributors know what exists, how it works, and how to extend it safely.
 
+CtrlSpeak distinguishes between interactive tooling and the system-managed services that keep the LangGraph workflow healthy. Modules under `tools/` are invoked directly by personas or users, while the background agents in `background_agents/` are orchestrator-managed services that refresh documentation, maintain temporal context, and clean up `<think>` output as described in the [Chat with Bot speech pipeline](../README.md#chat-with-bot-speech-pipeline) and [LangGraph orchestration and persistence](bot_integration.md#langgraph-orchestration-and-persistence) guides.
+
 The guidance below applies to the `tools/` package and any future modules that belong to it. When you add, modify, or remove a tool you **must** update this document in the same pull request.
 
 ## Directory layout


### PR DESCRIPTION
## Summary
- expand the README repository layout entry to describe background agents as orchestrator-managed services
- clarify the tooling guide introduction to contrast interactive tools with orchestrator-managed agents and cross-link to the orchestration docs

## Testing
- python -m compileall .
- python -m pytest -m core_headless


------
https://chatgpt.com/codex/tasks/task_e_68defe09cc2c832abf88e47a0f49a1de