### PR TITLE
Remove clipboard usage from error notifications

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -27,4 +27,5 @@ This living backlog tracks follow-up work the developer wants to schedule for Ct
 - Package and distribute the application through an app store or hosted download site to simplify delivery and onboarding.
 - Provide a sandboxed Python execution service (e.g., Pyodide or Firejail-backed runner) so Einstein can generate and execute short scripts safely when answering complex questions.
 - Expose a user-facing tool registry that lets operators define custom Create/Add tools (with schema validation and permission scopes) that Einstein can discover at runtime.
+- Add a "Send Bug Report" action that packages recent entries from `CtrlSpeak-error.log` and submits them to a configurable support endpoint.
 

--- a/utils/system.py
+++ b/utils/system.py
@@ -42,10 +42,6 @@ from utils.config_paths import (
 logger = get_logger(__name__)
 
 
-_CLIPBOARD_WARN_COOLDOWN_SECONDS = 5.0
-_last_clipboard_warning: float = 0.0
-
-
 def _bootstrap_runtime_environment() -> None:
     """
     Ensure third-party services can establish HTTPS connections when running
@@ -155,7 +151,6 @@ if TYPE_CHECKING:
 # Win32 text insertion / clipboard
 from utils.winio import (
     insert_text_into_focus, set_force_sendinput, is_console_window,
-    set_clipboard_text,
 )
 
 # LAN discovery (single source of truth for ServerInfo)
@@ -269,25 +264,19 @@ def write_error_log(context: str, snippet: str) -> None:
         logger.exception("Failed to write error log entry")
 
 
-def copy_to_clipboard(text: str) -> None:
-    global _last_clipboard_warning
-    try:
-        if not set_clipboard_text(text):
-            now = time.monotonic()
-            if now - _last_clipboard_warning >= _CLIPBOARD_WARN_COOLDOWN_SECONDS:
-                logger.warning(
-                    "Failed to stage clipboard text; the Windows clipboard is busy or unavailable."
-                )
-                _last_clipboard_warning = now
-    except Exception:
-        logger.exception("Failed to copy text to clipboard")
-
 def notify_error(context: str, details: str) -> None:
     snippet = (details or "").strip() or "Unknown error"
     message = f"{context}\n\nDetails:\n{snippet}"
     write_error_log(context, snippet)
-    copy_to_clipboard(message)
-    notify(message, title="CtrlSpeak Error")
+    logger.error("%s\n\nDetails:\n%s", context, snippet)
+    try:
+        print(f"CtrlSpeak Error:\n{message}")
+    except Exception:
+        logger.exception("Failed to print error details to terminal")
+    notify(
+        "An error occurred. Please review the terminal output or CtrlSpeak-error.log and contact support.",
+        title="CtrlSpeak Error",
+    )
 
 
 def format_exception_details(exc: BaseException | None) -> str:


### PR DESCRIPTION
## Summary
- stop copying error notifications to the Windows clipboard and instead log and print the details
- adjust the popup message to direct users to the terminal/log file for diagnostics
- document a follow-up task to add a Send Bug Report action for shipping error logs

## Testing
- python -m compileall .
- python -m pytest -m core_headless


------
https://chatgpt.com/codex/tasks/task_e_68df17a24340832a9a8f9281a8e5c858