### PR TITLE
Make Clear Bot Memory button red

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -1455,7 +1455,7 @@ class ManagementWindow:
         self.clear_memory_button = ttk.Button(
             bot_buttons,
             text="Clear Bot Memory",
-            style="Subtle.TButton",
+            style="Danger.TButton",
             command=self._clear_bot_memory,
         )
         self.clear_memory_button.pack(fill=tk.X, pady=4)


### PR DESCRIPTION
## Summary
- style the Control Speak management window's Clear Bot Memory button with the danger theme so it matches other red actions.

## Testing
- python -m compileall .
- python -m pytest -m core_headless

------
https://chatgpt.com/codex/tasks/task_e_68e1615965e8832a800579e75697c988