### PR TITLE
Remove unused conversation keyword accessors

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -101,8 +101,6 @@ The keyword registry keeps voice and command triggers in one place so assistants
 | `detect_conversation_end_keyword(text: str) -> Optional[KeywordMatch]` | Detects `goodbye <identity>` requests for the active conversation. |
 | `iter_keyword_matches(text: str, keywords: Iterable[Keyword]) -> Iterator[KeywordMatch]` | Generator that yields every keyword match found in the provided text. |
 | `get_vision_keyword(payload: str) -> Optional[Keyword]` | Retrieves the configured keyword metadata for `"screen"`, `"clipboard"`, or future vision payloads. |
-| `get_conversation_start_keyword(payload: str) -> Optional[Keyword]` | Returns the keyword definition for a conversation-start trigger associated with the provided identity payload. |
-| `get_conversation_end_keyword(payload: str) -> Optional[Keyword]` | Returns the keyword definition for a conversation-end trigger associated with the provided identity payload. |
 | `Keyword` / `KeywordMatch` | Lightweight dataclasses describing configured keywords and successful matches, including the compiled regex pattern for downstream substitutions. |
 
 ### Usage pattern

--- a/tools/keywords.py
+++ b/tools/keywords.py
@@ -284,26 +284,6 @@ def detect_conversation_end_keyword(text: str) -> Optional[KeywordMatch]:
     return find_first_keyword(text, _CONVERSATION_END_KEYWORDS)
 
 
-def get_conversation_start_keyword(payload: str) -> Optional[Keyword]:
-    """Retrieve a conversation-start keyword by its payload."""
-
-    normalized = payload.strip()
-    for keyword in _CONVERSATION_START_KEYWORDS:
-        if keyword.payload.lower() == normalized.lower():
-            return keyword
-    return None
-
-
-def get_conversation_end_keyword(payload: str) -> Optional[Keyword]:
-    """Retrieve a conversation-end keyword by its payload."""
-
-    normalized = payload.strip()
-    for keyword in _CONVERSATION_END_KEYWORDS:
-        if keyword.payload.lower() == normalized.lower():
-            return keyword
-    return None
-
-
 def _tokenize_for_fuzzy(text: str) -> list[str]:
     return [token for token in re.split(r"[^a-z0-9]+", text.lower()) if token]
 
@@ -362,6 +342,4 @@ __all__ = [
     "configure_identity_keywords",
     "detect_conversation_start_keyword",
     "detect_conversation_end_keyword",
-    "get_conversation_start_keyword",
-    "get_conversation_end_keyword",
 ]


### PR DESCRIPTION
## Summary
- remove the unused conversation keyword lookup helpers from `tools/keywords`
- update `docs/tooling.md` to reflect the slimmer keyword API

## Testing
- python -m pytest -m core_headless

------
https://chatgpt.com/codex/tasks/task_e_68e1b2565b04832aa50e0522e327e94e